### PR TITLE
upcoming: [DI-21322] - Revert useMemo changes and introduce deep equal logic and contextual view enabled.

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -2,6 +2,7 @@ import { dashboardFactory } from 'src/factories';
 import { databaseQueries } from 'src/queries/databases/databases';
 
 import { RESOURCES } from './constants';
+import { deepEqual } from './FilterBuilder';
 import {
   buildXFilter,
   checkIfAllMandatoryFiltersAreSelected,
@@ -263,4 +264,40 @@ it('test constructAdditionalRequestFilters method', () => {
 
   expect(result).toBeDefined();
   expect(result.length).toEqual(0);
+});
+
+it('returns true for identical primitive values', () => {
+  expect(deepEqual(1, 1)).toBe(true);
+  expect(deepEqual('test', 'test')).toBe(true);
+  expect(deepEqual(true, true)).toBe(true);
+});
+
+it('returns false for different primitive values', () => {
+  expect(deepEqual(1, 2)).toBe(false);
+  expect(deepEqual('test', 'other')).toBe(false);
+  expect(deepEqual(true, false)).toBe(false);
+});
+
+it('returns true for identical objects', () => {
+  const obj1 = { a: 1, b: { c: 2 } };
+  const obj2 = { a: 1, b: { c: 2 } };
+  expect(deepEqual(obj1, obj2)).toBe(true);
+});
+
+it('returns false for different objects', () => {
+  const obj1 = { a: 1, b: { c: 2 } };
+  const obj2 = { a: 1, b: { c: 3 } };
+  expect(deepEqual(obj1, obj2)).toBe(false);
+});
+
+it('returns true for identical arrays', () => {
+  const arr1 = [1, 2, 3];
+  const arr2 = [1, 2, 3];
+  expect(deepEqual(arr1, arr2)).toBe(true);
+});
+
+it('returns false for different arrays', () => {
+  const arr1 = [1, 2, 3];
+  const arr2 = [1, 2, 4];
+  expect(deepEqual(arr1, arr2)).toBe(false);
 });

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -373,3 +373,70 @@ const getDependentFiltersByFilterKey = (
         : configuration.filterKey
     );
 };
+
+
+/**
+ * @param obj1 The first object to be compared
+ * @param obj2 The second object to be compared
+ * @returns True if, both are equal else false
+ */
+export const deepEqual = <T>(obj1: T, obj2: T): boolean => {
+  if (obj1 === obj2) {
+    return true; // Identical references or values
+  }
+
+  // If either is null or undefined, or they are not of object type, return false
+  if (
+    obj1 === null ||
+    obj2 === null ||
+    typeof obj1 !== 'object' ||
+    typeof obj2 !== 'object'
+  ) {
+    return false;
+  }
+
+  // Handle array comparison separately
+  if (Array.isArray(obj1) && Array.isArray(obj2)) {
+    return compareArrays(obj1, obj2);
+  }
+
+  // Ensure both objects have the same number of keys
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  // Recursively check each key
+  for (const key of keys1) {
+    if (!(key in obj2)) {
+      return false;
+    }
+    // Recursive deep equal check
+    if (!deepEqual((obj1 as any)[key], (obj2 as any)[key])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * @param arr1 Array for comparison
+ * @param arr2 Array for comparison
+ * @returns True if, both the arrays are equal, else false
+ */
+const compareArrays = <T>(arr1: T[], arr2: T[]): boolean => {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (!deepEqual(arr1[i], arr2[i])) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -65,13 +65,17 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
       preferences,
     } = props;
 
-    const [dependentFilters, setDependentFilters] = React.useState<{
+    const [, setDependentFilters] = React.useState<{
       [key: string]: FilterValueType;
     }>({});
 
     const [showFilter, setShowFilter] = React.useState<boolean>(true);
 
     const theme = useTheme();
+
+    const dependentFilterReference: React.MutableRefObject<{
+      [key: string]: FilterValueType;
+    }> = React.useRef({});
 
     const checkAndUpdateDependentFilters = React.useCallback(
       (filterKey: string, value: FilterValueType) => {
@@ -82,16 +86,13 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           for (const filter of filters) {
             if (
               Boolean(filter?.configuration.dependency?.length) &&
-              filter?.configuration.dependency?.includes(filterKey)
+              filter?.configuration.dependency?.includes(filterKey) &&
+              dependentFilterReference.current[filterKey] !== value
             ) {
-              // Use the functional form to ensure you're always working with the latest state
-              setDependentFilters((prev) => {
-                // Only update if the value is different
-                if (prev[filterKey] !== value) {
-                  return { ...prev, [filterKey]: value };
-                }
-                return prev; // If no change, return the previous state
-              });
+              dependentFilterReference.current[filterKey] = value;
+              setDependentFilters(() => ({
+                ...dependentFilterReference.current,
+              }));
               break;
             }
           }
@@ -184,7 +185,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             {
               config,
               dashboard,
-              dependentFilters: dependentFilters,
+              dependentFilters: dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
             },
@@ -195,7 +196,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             {
               config,
               dashboard,
-              dependentFilters: dependentFilters,
+              dependentFilters: dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
             },
@@ -210,7 +211,6 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
         handleCustomSelectChange,
         isServiceAnalyticsIntegration,
         preferences,
-        dependentFilters,
       ]
     );
 
@@ -218,7 +218,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
       setShowFilter((showFilterPrev) => !showFilterPrev);
     };
 
-    const RenderFilters = React.useMemo(() => {
+    const RenderFilters = React.useCallback(() => {
       const filters = FILTER_CONFIG.get(dashboard.service_type)?.filters || [];
 
       if (!filters || filters.length === 0) {
@@ -251,7 +251,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             })}
           </Grid>
         ));
-    }, [dashboard, getProps, isServiceAnalyticsIntegration, dependentFilters]);
+    }, [dashboard, getProps, isServiceAnalyticsIntegration]);
 
     if (
       !dashboard ||
@@ -315,7 +315,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           rowGap={2}
           xs={12}
         >
-          {RenderFilters}
+          <RenderFilters />
         </Grid>
       </Grid>
     );
@@ -330,6 +330,6 @@ function compareProps(
   return (
     oldProps.dashboard?.id === newProps.dashboard?.id &&
     oldProps.preferences?.[DASHBOARD_ID] ===
-    newProps.preferences?.[DASHBOARD_ID]
+      newProps.preferences?.[DASHBOARD_ID]
   );
 }

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -251,7 +251,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             })}
           </Grid>
         ));
-    }, [dashboard, getProps, isServiceAnalyticsIntegration]);
+    }, [dashboard, getProps, isServiceAnalyticsIntegration, dependentFilters]);
 
     if (
       !dashboard ||

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -330,6 +330,6 @@ function compareProps(
   return (
     oldProps.dashboard?.id === newProps.dashboard?.id &&
     oldProps.preferences?.[DASHBOARD_ID] ===
-      newProps.preferences?.[DASHBOARD_ID]
+    newProps.preferences?.[DASHBOARD_ID]
   );
 }

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -4,6 +4,8 @@ import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
 import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
 import { themes } from 'src/utilities/theme';
 
+import { deepEqual } from '../Utils/FilterBuilder';
+
 import type { Filter, FilterValue } from '@linode/api-v4';
 
 export interface CloudPulseResources {
@@ -144,7 +146,7 @@ function compareProps(
       return false;
     }
   }
-  if (prevProps.xFilter !== nextProps.xFilter) {
+  if (!deepEqual(prevProps.xFilter, nextProps.xFilter)) {
     return false;
   }
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -24,6 +24,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import type { Engine } from '@linode/api-v4/lib/databases/types';
 import type { APIError } from '@linode/api-v4/lib/types';
+import { CloudPulseDashboardWithFilters } from 'src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters';
 
 const DatabaseSummary = React.lazy(() => import('./DatabaseSummary'));
 const DatabaseBackups = React.lazy(() => import('./DatabaseBackups'));
@@ -103,6 +104,11 @@ export const DatabaseDetail = () => {
       title: 'Resize',
     });
   }
+
+  tabs.push({
+    routeName: `/databases/${engine}/${id}/monitor`,
+    title: 'Monitor',
+  });
 
   const getTabIndex = () => {
     const tabChoice = tabs.findIndex((tab) =>
@@ -200,6 +206,12 @@ export const DatabaseDetail = () => {
             <DatabaseSettings
               database={database}
               disabled={isDatabasesGrantReadOnly}
+            />
+          </SafeTabPanel>
+          <SafeTabPanel index={flags.databaseResize ? 4 : 3}>
+            <CloudPulseDashboardWithFilters
+              dashboardId={2}
+              resource={database.id}
             />
           </SafeTabPanel>
         </TabPanels>


### PR DESCRIPTION
## Description 📝
Revert useMemo changes and introduce deep equal logic for resource selection retention and contextual view enabled.

## Changes  🔄

1. Revert useMemo changes and introduce deep equal logic for resource selection retention
2. Contextual view enabled

## Target release date 🗓️
08-10-2024

## As an Author I have considered 🤔

*Check all that apply*

- [x] Use React components instead of HTML Tags
- [x] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [x] Use appropriate types & avoid using "any"
- [x] No type casting & non-null assertions
- [x] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] Providing/Improving test coverage
- [x] Use sx props to pass styles instead of style prop
- [x] Add JSDoc comments for interface properties & functions
- [x] Use strict equality (===) instead of double equal (==)
- [x] Use of named arguments (interfaces) if function argument list exceeds size 2
- [x] Destructure the props
- [x] Keep component size small & move big computing functions to separate utility
- [x] 📱 Providing mobile support
