### PR TITLE
upcoming: [DI-21520] - Added default xFilter for fetching aiven clusters for dbass

### DIFF
--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardSelect.tsx
@@ -31,7 +31,10 @@ export const CloudPulseDashboardSelect = React.memo(
 
     const serviceTypes: string[] = formattedServiceTypes(serviceTypesList);
     const serviceTypeMap: Map<string, string> = new Map(
-      serviceTypesList?.data.map((item) => [item.service_type, item.label])
+      (serviceTypesList?.data || []).map((item) => [
+        item?.service_type ?? '',
+        item?.label ?? '',
+      ])
     );
 
     const {
@@ -95,9 +98,7 @@ export const CloudPulseDashboardSelect = React.memo(
         renderGroup={(params) => (
           <Box key={params.key}>
             <Typography sx={{ marginLeft: '3.5%' }} variant="h3">
-              {serviceTypeMap.has(params.group)
-                ? serviceTypeMap.get(params.group)
-                : params.group}
+              {serviceTypeMap.get(params.group) || params.group}
             </Typography>
             {params.children}
           </Box>

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardSelect.tsx
@@ -31,10 +31,9 @@ export const CloudPulseDashboardSelect = React.memo(
 
     const serviceTypes: string[] = formattedServiceTypes(serviceTypesList);
     const serviceTypeMap: Map<string, string> = new Map(
-      (serviceTypesList?.data || []).map((item) => [
-        item?.service_type ?? '',
-        item?.label ?? '',
-      ])
+      (serviceTypesList?.data || [])
+        .filter((item) => item?.service_type !== undefined)
+        .map((item) => [item.service_type, item.label ?? ''])
     );
 
     const {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -45,7 +45,13 @@ export const CloudPulseResourcesSelect = React.memo(
       disabled !== undefined ? !disabled : Boolean(region && resourceType),
       resourceType,
       {},
-      xFilter ? xFilter : { region }
+      resourceType === 'dbaas'
+        ? xFilter
+          ? { platform: 'rdbms-default', ...xFilter }
+          : { platform: 'rdbms-default', region }
+        : xFilter
+        ? xFilter
+        : { region }
     );
 
     const [selectedResources, setSelectedResources] = React.useState<

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -41,17 +41,22 @@ export const CloudPulseResourcesSelect = React.memo(
       xFilter,
     } = props;
 
+    const platformFilter =
+      resourceType === 'dbaas' ? { platform: 'rdbms-default' } : {};
+
     const { data: resources, isLoading } = useResourcesQuery(
       disabled !== undefined ? !disabled : Boolean(region && resourceType),
       resourceType,
       {},
-      resourceType === 'dbaas'
-        ? xFilter
-          ? { platform: 'rdbms-default', ...xFilter }
-          : { platform: 'rdbms-default', region }
-        : xFilter
-        ? xFilter
-        : { region }
+      xFilter
+        ? {
+            ...platformFilter,
+            ...xFilter,
+          }
+        : {
+            ...platformFilter,
+            region,
+          }
     );
 
     const [selectedResources, setSelectedResources] = React.useState<


### PR DESCRIPTION
## Description 📝
Added default xFilter for fetching aiven clusters for dbass

## Changes  🔄
List any change relevant to the reviewer.
- Introduced a new xFilter -> platform-rdbms for fetching aiven clusters for databases.

## Target release date 🗓️
--

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![](https://github.com/user-attachments/assets/d8602bdc-d031-4974-9d74-c3ec678ef138) | ![](https://github.com/user-attachments/assets/edd107a0-00e3-4fe6-8e1a-e94f2d45d2f1) |

## How to test 🧪

1. Disable mock user.
2. Select service - "Databases" in autocomplete showing "Select a Dashboard".
3. Select engine, node type, and region.
4. Click on the autocomplete showing "Select a DB cluster", you should only see aiven clusters listed.

## As an Author I have considered 🤔

*Check all that apply*

- [x] Use React components instead of HTML Tags
- [x] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [x] Use appropriate types & avoid using "any"
- [x] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [x] Use sx props to pass styles instead of style prop
- [x] Add JSDoc comments for interface properties & functions
- [x] Use strict equality (===) instead of double equal (==)
- [x] Use of named arguments (interfaces) if function argument list exceeds size 2
- [x] Destructure the props
- [x] Keep component size small & move big computing functions to separate utility
- [x] 📱 Providing mobile support
