### PR TITLE
upcoming: [DI-21520] - Add platform filter for jwe token fetch for aiven clusters in DBasS

### DIFF
--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -76,9 +76,6 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     isLoading: isDashboardLoading,
   } = useCloudPulseDashboardByIdQuery(dashboardId);
 
-  const platformFilter =
-    dashboard?.service_type === 'dbaas' ? { platform: 'rdbms-default' } : {};
-
   const {
     data: resourceList,
     isLoading: isResourcesLoading,
@@ -86,9 +83,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     Boolean(dashboard?.service_type),
     dashboard?.service_type,
     {},
-    {
-      platformFilter,
-    }
+    dashboard?.service_type === 'dbaas' ? { platform: 'rdbms-default' } : {}
   );
 
   const {

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -87,7 +87,7 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     dashboard?.service_type,
     {},
     {
-      ...platformFilter,
+      platformFilter,
     }
   );
 

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboard.tsx
@@ -76,6 +76,9 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     isLoading: isDashboardLoading,
   } = useCloudPulseDashboardByIdQuery(dashboardId);
 
+  const platformFilter =
+    dashboard?.service_type === 'dbaas' ? { platform: 'rdbms-default' } : {};
+
   const {
     data: resourceList,
     isLoading: isResourcesLoading,
@@ -83,7 +86,9 @@ export const CloudPulseDashboard = (props: DashboardProperties) => {
     Boolean(dashboard?.service_type),
     dashboard?.service_type,
     {},
-    {}
+    {
+      ...platformFilter,
+    }
   );
 
   const {


### PR DESCRIPTION
## Description 📝
Added default filter for fetching jwe token for aiven clusters in dbass

## Changes  🔄
- Introduced a new default filter -> platform-rdbms for fetching jwe token for aiven clusters in databases.

## Target release date 🗓️
28-10-2024

## Preview 📷

| Before  | After   |
| ------- | ------- |
|              |              |

## How to test 🧪.  (To be decided)

1. Disable mock user.
2. Select service - "Databases" in autocomplete showing "Select a Dashboard".
3. Select engine, node type, and region.
4. Click on the autocomplete showing "Select a DB cluster", select a dashboard.

## As an Author I have considered 🤔

*Check all that apply*

- [x] Use React components instead of HTML Tags
- [x] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [x] Use appropriate types & avoid using "any"
- [x] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [x] Use sx props to pass styles instead of style prop
- [x] Add JSDoc comments for interface properties & functions
- [x] Use strict equality (===) instead of double equal (==)
- [x] Use of named arguments (interfaces) if function argument list exceeds size 2
- [x] Destructure the props
- [x] Keep component size small & move big computing functions to separate utility
- [x] 📱 Providing mobile support