### PR TITLE
upcoming: [DI-20934] - Configurable Max limit on resource selection component

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -66,6 +66,7 @@ interface AclpFlag {
 
 export interface CloudPulseResourceTypeMapFlag {
   dimensionKey: string;
+  maxResourceSelections?: number;
   serviceType: string;
 }
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
@@ -252,7 +252,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     );
     expect(screen.getByText('Failed to fetch Resources.')).toBeInTheDocument();
   });
-  
+
   it('should be able to select limited resources', () => {
     queryMocks.useResourcesQuery.mockReturnValue({
       data: linodeFactory.buildList(12),
@@ -282,7 +282,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
       .filter((option) => option.getAttribute(ARIA_SELECTED) === 'true');
 
     expect(selectedOptions.length).toBe(10);
-
+    expect(selectedOptions[0].textContent).toBe('linode-14');
     expect(screen.getByRole('option', { name: `linode-24` })).toHaveAttribute(
       ARIA_DISABLED,
       'true'

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
@@ -282,7 +282,6 @@ describe('CloudPulseResourcesSelect component tests', () => {
       .filter((option) => option.getAttribute(ARIA_SELECTED) === 'true');
 
     expect(selectedOptions.length).toBe(10);
-    expect(selectedOptions[0].textContent).toBe('linode-14');
     expect(screen.getByRole('option', { name: `linode-24` })).toHaveAttribute(
       ARIA_DISABLED,
       'true'

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
@@ -22,7 +22,6 @@ const mockResourceHandler = vi.fn();
 const SELECT_ALL = 'Select All';
 const ARIA_SELECTED = 'aria-selected';
 const ARIA_DISABLED = 'aria-disabled';
-const labelText = 'Resources (10 max)';
 
 describe('CloudPulseResourcesSelect component tests', () => {
   it('should render disabled component if the the props are undefined or regions and service type does not have any resources', () => {
@@ -41,7 +40,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
       />
     );
     expect(getByTestId('resource-select')).toBeInTheDocument();
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
     expect(getByPlaceholderText('Select Resources')).toBeInTheDocument();
   }),
     it('should render resources happy path', () => {
@@ -60,7 +59,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
         />
       );
       fireEvent.click(screen.getByRole('button', { name: 'Open' }));
-      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+      expect(screen.getByLabelText('Resources')).toBeInTheDocument();
       expect(
         screen.getByRole('option', {
           name: 'linode-3',
@@ -89,7 +88,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
     fireEvent.click(screen.getByRole('option', { name: SELECT_ALL }));
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
     expect(
       screen.getByRole('option', {
         name: 'linode-5',
@@ -120,7 +119,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
     fireEvent.click(screen.getByRole('option', { name: SELECT_ALL }));
     fireEvent.click(screen.getByRole('option', { name: 'Deselect All' }));
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
     expect(
       screen.getByRole('option', {
         name: 'linode-7',
@@ -151,7 +150,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
     fireEvent.click(screen.getByRole('option', { name: 'linode-9' }));
     fireEvent.click(screen.getByRole('option', { name: 'linode-10' }));
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
 
     expect(
       screen.getByRole('option', {
@@ -272,7 +271,8 @@ describe('CloudPulseResourcesSelect component tests', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
-    expect(screen.getByLabelText(labelText)).toBeInTheDocument();
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
+    expect(screen.getByText('Select up to 10 Resources')).toBeInTheDocument();
 
     for (let i = 14; i <= 23; i++) {
       fireEvent.click(screen.getByRole('option', { name: `linode-${i}` }));

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -90,7 +90,7 @@ export const CloudPulseResourcesSelect = React.memo(
       return obj?.maxResourceSelections || 10;
     }, [resourceType, flags.aclpResourceTypeMap]);
 
-    const isMaxSelectionsReached = React.useMemo(() => {
+    const resourcesLimitReached = React.useMemo(() => {
       return getResourcesList.length > maxResourceSelectionLimit;
     }, [getResourcesList.length, maxResourceSelectionLimit]);
 
@@ -142,14 +142,14 @@ export const CloudPulseResourcesSelect = React.memo(
           const isResourceSelected = selectedResources?.some(
             (item) => item.label === option.label
           );
-          const isOverLimitOption =
+          const isMaxSelectionsReached =
             selectedResources &&
             selectedResources.length >= maxResourceSelectionLimit &&
             !isResourceSelected;
           return (
             <ListItem
               {...rest}
-              aria-disabled={isOverLimitOption}
+              aria-disabled={isMaxSelectionsReached}
               data-qa-option
               key={key}
             >
@@ -174,7 +174,7 @@ export const CloudPulseResourcesSelect = React.memo(
         autoHighlight
         clearOnBlur
         data-testid="resource-select"
-        disableSelectAll={isMaxSelectionsReached} // Select_All option will not be available if number of resources are higher than resource selection limit
+        disableSelectAll={resourcesLimitReached} // Select_All option will not be available if number of resources are higher than resource selection limit
         disabled={disabled}
         errorText={isError ? `Failed to fetch ${label || 'Resources'}.` : ''}
         helperText={

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -83,7 +83,8 @@ export const CloudPulseResourcesSelect = React.memo(
       return resources && resources.length > 0 ? resources : [];
     }, [resources]);
 
-    const setResourceLimit = React.useMemo(() => {
+    // Maximum resource selection limit is fetched from launchdarkly
+    const ResourceLimit = React.useMemo(() => {
       const obj = flags.aclpResourceTypeMap?.find(
         (item: CloudPulseResourceTypeMapFlag) =>
           item.serviceType === resourceType
@@ -92,8 +93,8 @@ export const CloudPulseResourcesSelect = React.memo(
     }, [resourceType, flags.aclpResourceTypeMap]);
 
     const resourceLimitReached = React.useMemo(() => {
-      return getResourcesList.length > setResourceLimit;
-    }, [getResourcesList.length, setResourceLimit]);
+      return getResourcesList.length > ResourceLimit;
+    }, [getResourcesList.length, ResourceLimit]);
 
     // Once the data is loaded, set the state variable with value stored in preferences
     React.useEffect(() => {
@@ -138,13 +139,14 @@ export const CloudPulseResourcesSelect = React.memo(
           selectedResources?.length ? '' : placeholder || 'Select Resources'
         }
         renderOption={(props, option) => {
+          // After selecting resources up to the max resource selection limit, rest of the unselected options will be disabled if there are any
           const { key, ...rest } = props;
           const isResourceSelected = selectedResources?.some(
             (item) => item.label === option.label
           );
           const isOverLimitOption =
             selectedResources &&
-            selectedResources?.length >= setResourceLimit &&
+            selectedResources.length >= ResourceLimit &&
             !isResourceSelected;
           return (
             <ListItem
@@ -174,11 +176,12 @@ export const CloudPulseResourcesSelect = React.memo(
         autoHighlight
         clearOnBlur
         data-testid="resource-select"
-        disableSelectAll={resourceLimitReached}
+        disableSelectAll={resourceLimitReached} // Select_All option will not be available if number of resources are higher than resource selection limit
         disabled={disabled}
         errorText={isError ? `Failed to fetch ${label || 'Resources'}.` : ''}
+        helperText={`Select up to ${ResourceLimit} ${label}`}
         isOptionEqualToValue={(option, value) => option.id === value.id}
-        label={`${label || 'Resources'} (${setResourceLimit} max)`}
+        label={label || 'Resources'}
         limitTags={2}
         loading={isLoading}
         multiple

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -179,7 +179,7 @@ export const CloudPulseResourcesSelect = React.memo(
         disableSelectAll={resourceLimitReached} // Select_All option will not be available if number of resources are higher than resource selection limit
         disabled={disabled}
         errorText={isError ? `Failed to fetch ${label || 'Resources'}.` : ''}
-        helperText={`Select up to ${ResourceLimit} ${label}`}
+        helperText={!isError ? `Select up to ${ResourceLimit} ${label}` : ''}
         isOptionEqualToValue={(option, value) => option.id === value.id}
         label={label || 'Resources'}
         limitTags={2}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -10,7 +10,6 @@ import { themes } from 'src/utilities/theme';
 import { deepEqual } from '../Utils/FilterBuilder';
 
 import type { Filter, FilterValue } from '@linode/api-v4';
-import type { CloudPulseResourceTypeMapFlag } from 'src/featureFlags';
 
 export interface CloudPulseResources {
   id: string;
@@ -86,10 +85,9 @@ export const CloudPulseResourcesSelect = React.memo(
     // Maximum resource selection limit is fetched from launchdarkly
     const maxResourceSelectionLimit = React.useMemo(() => {
       const obj = flags.aclpResourceTypeMap?.find(
-        (item: CloudPulseResourceTypeMapFlag) =>
-          item.serviceType === resourceType
+        (item) => item.serviceType === resourceType
       );
-      return obj ? obj.maxResourceSelections || 10 : 10;
+      return obj?.maxResourceSelections || 10;
     }, [resourceType, flags.aclpResourceTypeMap]);
 
     const isMaxSelectionsReached = React.useMemo(() => {
@@ -118,25 +116,6 @@ export const CloudPulseResourcesSelect = React.memo(
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [resources, region, xFilter, resourceType]);
-
-    // selected resources will appear at the top in the autcomplete popper
-    const resourcesWithSelectedFirst = React.useMemo<
-      CloudPulseResources[]
-    >(() => {
-      const selectedResourcesSet = new Set(
-        selectedResources?.map((item) => item.label)
-      );
-
-      const selectedResourcesList = getResourcesList.filter((resource) =>
-        selectedResourcesSet.has(resource.label)
-      );
-
-      const unselectedResourcesList = getResourcesList.filter(
-        (resource) => !selectedResourcesSet.has(resource.label)
-      );
-
-      return [...selectedResourcesList, ...unselectedResourcesList];
-    }, [getResourcesList, selectedResources]);
 
     return (
       <Autocomplete
@@ -207,7 +186,7 @@ export const CloudPulseResourcesSelect = React.memo(
         loading={isLoading}
         multiple
         noMarginTop
-        options={resourcesWithSelectedFirst}
+        options={getResourcesList}
         value={selectedResources ?? []}
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -95,7 +95,7 @@ export const CloudPulseResourcesSelect = React.memo(
     const resourceLimitReached = React.useMemo(() => {
       return getResourcesList.length > ResourceLimit;
     }, [getResourcesList.length, ResourceLimit]);
-
+    
     // Once the data is loaded, set the state variable with value stored in preferences
     React.useEffect(() => {
       if (resources && savePreferences && !selectedResources) {
@@ -118,6 +118,26 @@ export const CloudPulseResourcesSelect = React.memo(
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [resources, region, xFilter, resourceType]);
+
+    // selected resources will appear at the top in the autcomplete popper
+    const sortedResourcesList = React.useMemo<CloudPulseResources[]>(() => {
+      return [...getResourcesList].sort((resource_a, resource_b) => {
+        const aIsSelected = selectedResources?.some(
+          (item) => item.label === resource_a.label
+        );
+        const bIsSelected = selectedResources?.some(
+          (item) => item.label === resource_b.label
+        );
+
+        if (aIsSelected && !bIsSelected) {
+          return -1;
+        }
+        if (!aIsSelected && bIsSelected) {
+          return 1;
+        }
+        return 0;
+      });
+    }, [getResourcesList, selectedResources]);
 
     return (
       <Autocomplete
@@ -186,7 +206,7 @@ export const CloudPulseResourcesSelect = React.memo(
         loading={isLoading}
         multiple
         noMarginTop
-        options={getResourcesList}
+        options={sortedResourcesList}
         value={selectedResources ?? []}
       />
     );


### PR DESCRIPTION
## Description 📝
Introduction of configurable Max limit on resource selection component and other enhancements.

## Changes  🔄

1. SELECT_ALL option in resources list component will not be available if number of resources are higher than the maximum resources selection limit set in launchDarkly.
2. In resource selection autocomplete, user will be able to select resources up to maximum resource selection limit, all other resources(options) will be disabled after reaching this limit.
3. Selected resources will be at the top of the autocomplete popper list.
4. Text 'Select up to `limit` `label`' is introduced under resource selection autocomplete.

## Target release date 🗓️
--

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/0a128b6e-8ee8-488f-b4b7-f20fed1c78fc) | ![image](https://github.com/user-attachments/assets/dcc1a334-84a3-41e6-92b6-bc181464451c) |
| ![image](https://github.com/user-attachments/assets/e353d99f-cd75-4fd2-bb3a-d8232d8b01c3) | ![image](https://github.com/user-attachments/assets/b8163a6a-d71b-4f9f-a66c-b4e4948b8f0f) |

## How to test 🧪

### Verification steps

1. Login as a mock user.
2. Select any resource type - linode or databases, and the relevant filters.
3. If you have resources > max resource selection limit, you will not see any 'Select All' tab in resource selection autocomplete.
4. Try selecting any resource after you have already selected resources up to max limit, you will not be able to select any additional resource as they are disabled after reaching max selection limit.

## As an Author I have considered 🤔

*Check all that apply*

- [x] Use React components instead of HTML Tags
- [x] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [x] Use appropriate types & avoid using "any"
- [x] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [x] Providing/Improving test coverage
- [x] Use sx props to pass styles instead of style prop
- [x] Add JSDoc comments for interface properties & functions
- [x] Use strict equality (===) instead of double equal (==)
- [x] Use of named arguments (interfaces) if function argument list exceeds size 2
- [x] Destructure the props
- [x] Keep component size small & move big computing functions to separate utility
- [x] 📱 Providing mobile support

