### PR TITLE
resource order fix

### DIFF
--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -47,7 +47,7 @@ export const CloudPulseResourcesSelect = React.memo(
       resourceType === 'dbaas' ? { platform: 'rdbms-default' } : {};
 
     const orderFilter: Partial<Filter> =
-      resourceType === 'dbaas' ? { '+order': 'asc', '+order_by': 'id' } : {};
+      resourceType === 'dbaas' ? { '+order': 'asc', '+order_by': 'label' } : {};
 
     const { data: resources, isLoading, isError } = useResourcesQuery(
       disabled !== undefined ? !disabled : Boolean(region && resourceType),

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -46,17 +46,22 @@ export const CloudPulseResourcesSelect = React.memo(
     const platformFilter =
       resourceType === 'dbaas' ? { platform: 'rdbms-default' } : {};
 
+    const orderFilter: Partial<Filter> =
+      resourceType === 'dbaas' ? { '+order': 'asc', '+order_by': 'id' } : {};
+
     const { data: resources, isLoading, isError } = useResourcesQuery(
       disabled !== undefined ? !disabled : Boolean(region && resourceType),
       resourceType,
       {},
       xFilter
         ? {
-            ...platformFilter,
-            ...xFilter,
+            ...platformFilter, // platform is a top level filter
+            ...orderFilter, // order by filter
+            ...xFilter, // the usual xFilters
           }
         : {
             ...platformFilter,
+            ...orderFilter,
             region,
           }
     );


### PR DESCRIPTION
## Description 📝
Added one new filter - orderFilter for fetching instances in dbass servictype.

## Changes  🔄
- In our resource selection component, OrderFilter is added into the request for fetching databases instances in dbass serviceType. [**Reason for change**]: order_by filter not honored in api response causing react useEffect to clear response after getting same response in different order.

## Target release date 🗓️
--

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites
(How to setup test environment)
- ...
- ...

### Reproduction steps
(How to reproduce the issue, if applicable)
- ...
- ...

### Verification steps
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

---
