### PR TITLE
upcoming: [DI-21999] - Bug fix for resource selection component

### DIFF
--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
@@ -103,7 +103,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
   it('should be able to deselect the selected resources', () => {
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2),
+      data: linodeFactory.buildList(10),
       isError: false,
       isLoading: false,
       status: 'success',
@@ -148,23 +148,23 @@ describe('CloudPulseResourcesSelect component tests', () => {
       />
     );
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
-    fireEvent.click(screen.getByRole('option', { name: 'linode-9' }));
-    fireEvent.click(screen.getByRole('option', { name: 'linode-10' }));
+    fireEvent.click(screen.getByRole('option', { name: 'linode-17' }));
+    fireEvent.click(screen.getByRole('option', { name: 'linode-18' }));
     expect(screen.getByLabelText('Resources')).toBeInTheDocument();
 
     expect(
       screen.getByRole('option', {
-        name: 'linode-9',
+        name: 'linode-17',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-10',
+        name: 'linode-18',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-11',
+        name: 'linode-19',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
     expect(
@@ -183,7 +183,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     renderWithTheme(
       <CloudPulseResourcesSelect
-        defaultValue={['12']}
+        defaultValue={['20']}
         handleResourcesSelection={mockResourceHandler}
         label="Resources"
         region={'us-east'}
@@ -194,7 +194,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'linode-12',
+        name: 'linode-20',
       })
     ).toBeInTheDocument();
 
@@ -202,7 +202,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     expect(
       screen.getByRole('option', {
-        name: 'linode-13',
+        name: 'linode-21',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
   });
@@ -253,7 +253,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     expect(screen.getByText('Failed to fetch Resources.')).toBeInTheDocument();
   });
 
-  it('should be able to select limited resources', () => {
+  it('should be able to select limited resources and select/deselect all will not be available if resource are more than max resource selection limit', () => {
     queryMocks.useResourcesQuery.mockReturnValue({
       data: linodeFactory.buildList(12),
       isError: false,
@@ -274,7 +274,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     expect(screen.getByLabelText('Resources')).toBeInTheDocument();
     expect(screen.getByText('Select up to 10 Resources')).toBeInTheDocument();
 
-    for (let i = 14; i <= 23; i++) {
+    for (let i = 22; i <= 31; i++) {
       fireEvent.click(screen.getByRole('option', { name: `linode-${i}` }));
     }
     const selectedOptions = screen
@@ -282,7 +282,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
       .filter((option) => option.getAttribute(ARIA_SELECTED) === 'true');
 
     expect(selectedOptions.length).toBe(10);
-    expect(screen.getByRole('option', { name: `linode-24` })).toHaveAttribute(
+    expect(screen.getByRole('option', { name: `linode-32` })).toHaveAttribute(
       ARIA_DISABLED,
       'true'
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.test.tsx
@@ -103,7 +103,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
   it('should be able to deselect the selected resources', () => {
     queryMocks.useResourcesQuery.mockReturnValue({
-      data: linodeFactory.buildList(10),
+      data: linodeFactory.buildList(2),
       isError: false,
       isLoading: false,
       status: 'success',
@@ -148,23 +148,23 @@ describe('CloudPulseResourcesSelect component tests', () => {
       />
     );
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
-    fireEvent.click(screen.getByRole('option', { name: 'linode-17' }));
-    fireEvent.click(screen.getByRole('option', { name: 'linode-18' }));
+    fireEvent.click(screen.getByRole('option', { name: 'linode-9' }));
+    fireEvent.click(screen.getByRole('option', { name: 'linode-10' }));
     expect(screen.getByLabelText('Resources')).toBeInTheDocument();
 
     expect(
       screen.getByRole('option', {
-        name: 'linode-17',
+        name: 'linode-9',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-18',
+        name: 'linode-10',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'true');
     expect(
       screen.getByRole('option', {
-        name: 'linode-19',
+        name: 'linode-11',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
     expect(
@@ -183,7 +183,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     renderWithTheme(
       <CloudPulseResourcesSelect
-        defaultValue={['20']}
+        defaultValue={['12']}
         handleResourcesSelection={mockResourceHandler}
         label="Resources"
         region={'us-east'}
@@ -194,7 +194,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'linode-20',
+        name: 'linode-12',
       })
     ).toBeInTheDocument();
 
@@ -202,7 +202,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
 
     expect(
       screen.getByRole('option', {
-        name: 'linode-21',
+        name: 'linode-13',
       })
     ).toHaveAttribute(ARIA_SELECTED, 'false');
   });
@@ -274,7 +274,7 @@ describe('CloudPulseResourcesSelect component tests', () => {
     expect(screen.getByLabelText('Resources')).toBeInTheDocument();
     expect(screen.getByText('Select up to 10 Resources')).toBeInTheDocument();
 
-    for (let i = 22; i <= 31; i++) {
+    for (let i = 14; i <= 23; i++) {
       fireEvent.click(screen.getByRole('option', { name: `linode-${i}` }));
     }
     const selectedOptions = screen
@@ -282,11 +282,38 @@ describe('CloudPulseResourcesSelect component tests', () => {
       .filter((option) => option.getAttribute(ARIA_SELECTED) === 'true');
 
     expect(selectedOptions.length).toBe(10);
-    expect(screen.getByRole('option', { name: `linode-32` })).toHaveAttribute(
+    expect(screen.getByRole('option', { name: `linode-24` })).toHaveAttribute(
       ARIA_DISABLED,
       'true'
     );
 
     expect(queryByRole('option', { name: SELECT_ALL })).not.toBeInTheDocument();
+  });
+
+  it('should be able to select all and deselect all the resources when number of resources are equal to resource limit', () => {
+    queryMocks.useResourcesQuery.mockReturnValue({
+      data: linodeFactory.buildList(10),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    renderWithTheme(
+      <CloudPulseResourcesSelect
+        handleResourcesSelection={mockResourceHandler}
+        label="Resources"
+        region={'us-east'}
+        resourceType={'linode'}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.click(screen.getByRole('option', { name: SELECT_ALL }));
+    fireEvent.click(screen.getByRole('option', { name: 'Deselect All' }));
+    expect(screen.getByLabelText('Resources')).toBeInTheDocument();
+
+    for (let i = 26; i <= 35; i++) {
+      expect(
+        screen.getByRole('option', { name: `linode-${i}` })
+      ).toHaveAttribute(ARIA_SELECTED, 'false');
+    }
   });
 });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseResourcesSelect.tsx
@@ -1,8 +1,11 @@
-import { Box, ListItem } from '@mui/material';
+import { Box } from '@mui/material';
 import React from 'react';
 
 import { Autocomplete } from 'src/components/Autocomplete/Autocomplete';
-import { SelectedIcon } from 'src/components/Autocomplete/Autocomplete.styles';
+import {
+  SelectedIcon,
+  StyledListItem,
+} from 'src/components/Autocomplete/Autocomplete.styles';
 import { useFlags } from 'src/hooks/useFlags';
 import { useResourcesQuery } from 'src/queries/cloudpulse/resources';
 import { themes } from 'src/utilities/theme';
@@ -142,10 +145,20 @@ export const CloudPulseResourcesSelect = React.memo(
           const isResourceSelected = selectedResources?.some(
             (item) => item.label === option.label
           );
+
+          const isSelectAllORDeslectAllOption =
+            option.label === 'Select All ' || option.label === 'Deselect All ';
+
           const isMaxSelectionsReached =
             selectedResources &&
             selectedResources.length >= maxResourceSelectionLimit &&
-            !isResourceSelected;
+            !isResourceSelected &&
+            !isSelectAllORDeslectAllOption;
+
+          const ListItem = isSelectAllORDeslectAllOption
+            ? StyledListItem
+            : 'li';
+
           return (
             <ListItem
               {...rest}


### PR DESCRIPTION
## Description 📝
Bug fix for resource selection autocomplete

## Changes  🔄

1. Fixed deselect all disabling issue - While selecting exactly 10(maxResourceSelections) resources/clusters, deselect all was also getting disabled alongwith rest of the options when available number of resources were equal to maxResourceSelections.
2. Select all style with bold font restored.

## Target release date 🗓️
--

## Preview 📷
**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/d7cab03d-4d12-49de-9fc7-77888bb9c183) | ![image](https://github.com/user-attachments/assets/353776d8-a026-4ef9-badb-88cb7cf9b3ac) |

## How to test 🧪

### Prerequisites

### Verification steps
(How to verify changes)
- ...
- ...

## As an Author I have considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support
