### PR TITLE
upcoming: [DI-22875] - Zoom-in icon hover effect fix

### DIFF
--- a/packages/manager/src/assets/icons/zoomin.svg
+++ b/packages/manager/src/assets/icons/zoomin.svg
@@ -1,10 +1,10 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-<path d="M16.6667 7.5H12.5V3.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3.33331 7.5H7.49998V3.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3.33333 12.5001H7.5V16.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M16.6667 12.5001H12.5V16.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.5 7.5L17.5 2.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.5 7.5L2.5 2.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.5 12.5L2.5 17.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.5 12.5L17.5 17.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3333 2.5H17.5V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.66669 2.5H2.50002V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.66667 17.4999H2.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3333 17.4999H17.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.5 2.5L11.6667 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.49998 2.5L8.33331 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.5 17.5001L8.33333 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.5 17.5001L11.6667 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/manager/src/assets/icons/zoomout.svg
+++ b/packages/manager/src/assets/icons/zoomout.svg
@@ -1,10 +1,10 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.3333 2.5H17.5V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.66669 2.5H2.50002V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.66667 17.4999H2.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M13.3333 17.4999H17.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17.5 2.5L11.6667 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M2.49998 2.5L8.33331 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M2.5 17.5001L8.33333 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17.5 17.5001L11.6667 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6667 7.5H12.5V3.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.33331 7.5H7.49998V3.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.33333 12.5001H7.5V16.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6667 12.5001H12.5V16.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 7.5L17.5 2.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 7.5L2.5 2.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 12.5L2.5 17.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 12.5L17.5 17.5" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/manager/src/assets/icons/zoomout.svg
+++ b/packages/manager/src/assets/icons/zoomout.svg
@@ -1,10 +1,10 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.3333 2.5H17.5V6.66667" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.66669 2.5H2.50002V6.66667" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.66667 17.4999H2.5V13.3333" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M13.3333 17.4999H17.5V13.3333" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17.5 2.5L11.6667 8.33333" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M2.49998 2.5L8.33331 8.33333" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M2.5 17.5001L8.33333 11.6667" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17.5 17.5001L11.6667 11.6667" stroke="#888F91" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.3333 2.5H17.5V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.66669 2.5H2.50002V6.66667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.66667 17.4999H2.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3333 17.4999H17.5V13.3333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.5 2.5L11.6667 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.49998 2.5L8.33331 8.33333" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.5 17.5001L8.33333 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.5 17.5001L11.6667 11.6667" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.test.tsx
@@ -10,21 +10,21 @@ describe('Cloud Pulse Zoomer', () => {
   it('Should render zoomer with zoom-out button', () => {
     const props: ZoomIconProperties = {
       handleZoomToggle: vi.fn(),
-      zoomIn: false,
+      zoomIn: true,
     };
     const { getByTestId } = renderWithTheme(<ZoomIcon {...props} />);
 
     expect(getByTestId('zoom-out')).toBeInTheDocument();
-    expect(getByTestId('Maximize')).toBeInTheDocument(); // test id for tooltip
+    expect(getByTestId('Minimize')).toBeInTheDocument(); // test id for tooltip
   }),
     it('Should render zoomer with zoom-in button', () => {
       const props: ZoomIconProperties = {
         handleZoomToggle: vi.fn(),
-        zoomIn: true,
+        zoomIn: false,
       };
       const { getByTestId } = renderWithTheme(<ZoomIcon {...props} />);
 
       expect(getByTestId('zoom-in')).toBeInTheDocument();
-      expect(getByTestId('Minimize')).toBeInTheDocument(); // test id for tooltip
+      expect(getByTestId('Maximize')).toBeInTheDocument(); // test id for tooltip
     });
 });

--- a/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
@@ -29,11 +29,11 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
               fontSize: 'x-large',
               padding: '0',
             }}
-            aria-label="Zoom In"
-            data-testid="zoom-in"
+            aria-label="Zoom Out"
+            data-testid="zoom-out"
             onClick={() => handleClick(false)}
           >
-            <ZoomInMap />
+            <ZoomOutMap />
           </IconButton>
         </CloudPulseTooltip>
       );
@@ -47,11 +47,11 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
             fontSize: 'x-large',
             padding: 0,
           }}
-          aria-label="Zoom Out"
-          data-testid="zoom-out"
+          aria-label="Zoom In"
+          data-testid="zoom-in"
           onClick={() => handleClick(true)}
         >
-          <ZoomOutMap />
+          <ZoomInMap />
         </IconButton>
       </CloudPulseTooltip>
     );


### PR DESCRIPTION
## Description 📝
Change in color is observed when zoom-in icon is hovered over.

## Changes  🔄
- Zoom-in icon will have a changed color when hovered over.

_Note_: Only the first commit is related to the actual bug fix, rest are just naming corrections. 

## Target release date 🗓️
--

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/04f22a90-2f3e-42a6-864a-993174a0a8cb) | ![image](https://github.com/user-attachments/assets/30739ad6-a519-479a-a494-2b3173b0291d) |

## How to test 🧪

### Verification steps

- Navigate to monitor tab, select all the filters.
- Locate zoom icon, observe the change in color while hovering. Try toggling to zoom-in/zoom-out and verify the change in color while hovering in both forms.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---
