### PR TITLE
upcoming: [DI-22941] - Update dependency and order for tags

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.test.ts
@@ -13,6 +13,7 @@ import {
   getMetricsCallCustomFilters,
   getRegionProperties,
   getResourcesProperties,
+  getTagsProperties,
   getTimeDurationProperties,
 } from './FilterBuilder';
 import { deepEqual, getFilters } from './FilterBuilder';
@@ -49,6 +50,38 @@ it('test getRegionProperties method', () => {
     expect(handleRegionChange).toBeDefined();
     expect(selectedDashboard).toEqual(mockDashboard);
     expect(label).toEqual(name);
+  }
+});
+
+it('test getTagsProperties', () => {
+  const tagsConfig = linodeConfig?.filters.find(
+    (filterObj) => filterObj.name === 'Tags'
+  );
+
+  expect(tagsConfig).toBeDefined();
+
+  if (tagsConfig) {
+    const {
+      disabled,
+      handleTagsChange,
+      label,
+      region,
+      resourceType,
+    } = getTagsProperties(
+      {
+        config: tagsConfig,
+        dashboard: mockDashboard,
+        dependentFilters: { region: 'us-east' },
+        isServiceAnalyticsIntegration: true,
+      },
+      vi.fn()
+    );
+    const { name } = tagsConfig.configuration;
+    expect(handleTagsChange).toBeDefined();
+    expect(disabled).toEqual(false);
+    expect(label).toEqual(name);
+    expect(region).toEqual('us-east');
+    expect(resourceType).toEqual('linode');
   }
 });
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -64,7 +64,6 @@ export const getTagsProperties = (
 ): CloudPulseTagsSelectProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
   const {
-    config,
     dashboard,
     dependentFilters,
     isServiceAnalyticsIntegration,
@@ -84,7 +83,6 @@ export const getTagsProperties = (
     region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
-    xFilter: buildXFilter(config, dependentFilters ?? {}),
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -64,6 +64,7 @@ export const getTagsProperties = (
 ): CloudPulseTagsSelectProps => {
   const { filterKey, name: label, placeholder } = props.config.configuration;
   const {
+    config,
     dashboard,
     dependentFilters,
     isServiceAnalyticsIntegration,
@@ -83,6 +84,7 @@ export const getTagsProperties = (
     region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
+    xFilter: buildXFilter(config, dependentFilters ?? {}),
   };
 };
 

--- a/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterBuilder.ts
@@ -54,6 +54,7 @@ interface CloudPulseMandatoryFilterCheckProps {
  * @param config - accepts a CloudPulseServiceTypeFilters of tag key
  * @param handleTagsChange - the callback when we select new tag
  * @param dashboard - the selected dashboard's service type
+ * @param dependentFilters - tags are dependent on region filter, we need this for disabling the tags selection component
  * @param isServiceAnalyticsIntegration - only if this is false, we need to save preferences , else no need
  * @returns CloudPulseTagSelectProps
  */
@@ -61,14 +62,25 @@ export const getTagsProperties = (
   props: CloudPulseFilterProperties,
   handleTagsChange: (tags: CloudPulseTags[], savePref?: boolean) => void
 ): CloudPulseTagsSelectProps => {
-  const { name: label, placeholder } = props.config.configuration;
-  const { dashboard, isServiceAnalyticsIntegration, preferences } = props;
+  const { filterKey, name: label, placeholder } = props.config.configuration;
+  const {
+    dashboard,
+    dependentFilters,
+    isServiceAnalyticsIntegration,
+    preferences,
+  } = props;
   return {
     defaultValue: preferences?.[TAGS],
+    disabled: checkIfWeNeedToDisableFilterByFilterKey(
+      filterKey,
+      dependentFilters ?? {},
+      dashboard
+    ),
     handleTagsChange,
     label,
     optional: props.config.configuration.isOptional,
     placeholder,
+    region: dependentFilters?.[REGION],
     resourceType: dashboard.service_type,
     savePreferences: !isServiceAnalyticsIntegration,
   };

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -75,6 +75,22 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        dependency: ['region'],
+        filterKey: 'tags',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        isMultiSelect: true,
+        isOptional: true,
+        name: 'Tags',
+        neededInServicePage: false,
+        placeholder: 'Select Tags',
+        priority: 4,
+      },
+      name: 'Tags',
+    },
+    {
+      configuration: {
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -75,22 +75,6 @@ export const DBAAS_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
-        dependency: ['region'],
-        filterKey: 'tags',
-        filterType: 'string',
-        isFilterable: false,
-        isMetricsFilter: false,
-        isMultiSelect: true,
-        isOptional: true,
-        name: 'Tags',
-        neededInServicePage: false,
-        placeholder: 'Select Tags',
-        priority: 4,
-      },
-      name: 'Tags',
-    },
-    {
-      configuration: {
         filterKey: 'engine',
         filterType: 'string',
         isFilterable: false, // isFilterable -- this determines whethere you need to pass it metrics api

--- a/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/FilterConfig.ts
@@ -11,6 +11,19 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
   filters: [
     {
       configuration: {
+        filterKey: 'region',
+        filterType: 'string',
+        isFilterable: false,
+        isMetricsFilter: false,
+        name: 'Region',
+        neededInServicePage: false,
+        priority: 1,
+      },
+      name: 'Region',
+    },
+    {
+      configuration: {
+        dependency: ['region'],
         filterKey: 'tags',
         filterType: 'string',
         isFilterable: false,
@@ -23,18 +36,6 @@ export const LINODE_CONFIG: Readonly<CloudPulseServiceTypeFilterMap> = {
         priority: 4,
       },
       name: 'Tags',
-    },
-    {
-      configuration: {
-        filterKey: 'region',
-        filterType: 'string',
-        isFilterable: false,
-        isMetricsFilter: false,
-        name: 'Region',
-        neededInServicePage: false,
-        priority: 1,
-      },
-      name: 'Region',
     },
     {
       configuration: {

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -138,6 +138,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
           selectedTags,
           savePref,
           {
+            [RESOURCE_ID]: undefined,
             [TAGS]: selectedTags,
           }
         );
@@ -171,6 +172,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
         const updatedPreferenceData = {
           [REGION]: region,
           [RESOURCES]: undefined,
+          [TAGS]: undefined,
         };
         emitFilterChangeByFilterKey(
           REGION,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDashboardFilterBuilder.tsx
@@ -209,6 +209,7 @@ export const CloudPulseDashboardFilterBuilder = React.memo(
             {
               config,
               dashboard,
+              dependentFilters: dependentFilterReference.current,
               isServiceAnalyticsIntegration,
               preferences,
             },

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -16,6 +16,7 @@ const props: CloudPulseTagsSelectProps = {
   optional: true,
   region: 'us-east',
   resourceType: 'linode',
+  xFilter: { region: 'us-east' },
 };
 
 const queryMocks = vi.hoisted(() => ({
@@ -85,13 +86,13 @@ describe('CloudPulseTagsSelect component tests', () => {
     const user = userEvent.setup();
 
     queryMocks.useAllLinodesQuery.mockReturnValue({
-      data: linodeFactory.buildList(2, { tags: ['tag-2', 'tag-3'] }),
+      data: [],
       isError: false,
       isLoading: false,
       status: 'success',
     });
     const { getByRole, queryAllByRole } = renderWithTheme(
-      <CloudPulseTagsSelect {...props} region={'us-central'} />
+      <CloudPulseTagsSelect {...props} xFilter={{ region: 'us-central' }} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     const options = queryAllByRole('option');

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -16,7 +16,6 @@ const props: CloudPulseTagsSelectProps = {
   optional: true,
   region: 'us-east',
   resourceType: 'linode',
-  xFilter: { region: 'us-east' },
 };
 
 const queryMocks = vi.hoisted(() => ({
@@ -92,7 +91,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByRole, queryAllByRole } = renderWithTheme(
-      <CloudPulseTagsSelect {...props} xFilter={{ region: 'us-central' }} />
+      <CloudPulseTagsSelect {...props} region={'us-central'} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     const options = queryAllByRole('option');

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.test.tsx
@@ -6,7 +6,17 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { CloudPulseTagsSelect } from './CloudPulseTagsFilter';
 
+import type { CloudPulseTagsSelectProps } from './CloudPulseTagsFilter';
 import type { useAllLinodesQuery } from 'src/queries/linodes/linodes';
+
+const props: CloudPulseTagsSelectProps = {
+  disabled: false,
+  handleTagsChange: vi.fn(),
+  label: 'Tags',
+  optional: true,
+  region: 'us-east',
+  resourceType: 'linode',
+};
 
 const queryMocks = vi.hoisted(() => ({
   useAllLinodesQuery: vi.fn().mockReturnValue({}),
@@ -20,7 +30,6 @@ vi.mock('src/queries/linodes/linodes', async () => {
   };
 });
 
-const mockTagsHandler = vi.fn();
 const SELECT_ALL = 'Select All';
 const ARIA_SELECTED = 'aria-selected';
 const LABEL_SUBTITLE = 'Tags (optional)';
@@ -41,17 +50,24 @@ describe('CloudPulseTagsSelect component tests', () => {
       getByLabelText,
       getByPlaceholderText,
       getByTestId,
-    } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType="linode"
-      />
-    );
+    } = renderWithTheme(<CloudPulseTagsSelect {...props} />);
     expect(getByTestId('tags-select')).toBeInTheDocument();
     expect(getByLabelText(LABEL_SUBTITLE)).toBeInTheDocument();
     expect(getByPlaceholderText('Select Tags')).toBeInTheDocument();
+  });
+
+  it('should render a disabled Tags Select component when disabled is true or region is undefined', () => {
+    queryMocks.useAllLinodesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const { getByRole } = renderWithTheme(
+      <CloudPulseTagsSelect {...props} disabled={true} />
+    );
+
+    expect(getByRole('button', { name: 'Open' })).toBeDisabled();
   });
 
   it('should render a Tags Select component with error message on api call failure', () => {
@@ -60,18 +76,29 @@ describe('CloudPulseTagsSelect component tests', () => {
       isError: true,
       isLoading: false,
     } as ReturnType<typeof useAllLinodesQuery>);
-    const { getByText } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        resourceType="linode"
-      />
-    );
+    const { getByText } = renderWithTheme(<CloudPulseTagsSelect {...props} />);
 
     expect(getByText('Failed to fetch Tags.'));
   });
 
-  it('should select multiple tags', async () => {
+  it('should render a Tags Select component with tags filtered based on the selected region', async () => {
+    const user = userEvent.setup();
+
+    queryMocks.useAllLinodesQuery.mockReturnValue({
+      data: linodeFactory.buildList(2, { tags: ['tag-2', 'tag-3'] }),
+      isError: false,
+      isLoading: false,
+      status: 'success',
+    });
+    const { getByRole, queryAllByRole } = renderWithTheme(
+      <CloudPulseTagsSelect {...props} region={'us-central'} />
+    );
+    await user.click(getByRole('button', { name: 'Open' }));
+    const options = queryAllByRole('option');
+    expect(options).toHaveLength(0); // no tags for the selected region
+  });
+
+  it('should select multiple tags from the tags filtered based on the selected region', async () => {
     const user = userEvent.setup();
 
     queryMocks.useAllLinodesQuery.mockReturnValue({
@@ -83,12 +110,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByLabelText, getByRole } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType={'linode'}
-      />
+      <CloudPulseTagsSelect {...props} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     await user.click(getByRole('option', { name: 'tag-2' }));
@@ -122,12 +144,7 @@ describe('CloudPulseTagsSelect component tests', () => {
       status: 'success',
     });
     const { getByLabelText, getByRole } = renderWithTheme(
-      <CloudPulseTagsSelect
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        optional
-        resourceType={'linode'}
-      />
+      <CloudPulseTagsSelect {...props} />
     );
     await user.click(getByRole('button', { name: 'Open' }));
     await user.click(getByRole('option', { name: SELECT_ALL }));
@@ -156,10 +173,8 @@ describe('CloudPulseTagsSelect component tests', () => {
 
     const { getByRole } = renderWithTheme(
       <CloudPulseTagsSelect
+        {...props}
         defaultValue={['tag-2']}
-        handleTagsChange={mockTagsHandler}
-        label="Tags"
-        resourceType={'linode'}
         savePreferences
       />
     );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -4,10 +4,8 @@ import React from 'react';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { themes } from 'src/utilities/theme';
 
-import { deepEqual } from '../Utils/FilterBuilder';
-
 import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
-import type { Filter, FilterValue, Linode } from '@linode/api-v4';
+import type { FilterValue, Linode } from '@linode/api-v4';
 
 export interface CloudPulseTags {
   label: string;
@@ -23,7 +21,6 @@ export interface CloudPulseTagsSelectProps {
   region: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
-  xFilter?: Filter;
 }
 
 export const CloudPulseTagsSelect = React.memo(
@@ -38,12 +35,12 @@ export const CloudPulseTagsSelect = React.memo(
       region,
       resourceType,
       savePreferences,
-      xFilter,
     } = props;
 
+    const regionFilter = region ? (region as string) : undefined;
     const { data: linodesByRegion, isError, isLoading } = useAllLinodesQuery(
       {},
-      xFilter ? xFilter : { region: region as string },
+      { region: regionFilter },
       !disabled && Boolean(region && resourceType)
     );
 
@@ -82,7 +79,7 @@ export const CloudPulseTagsSelect = React.memo(
         setSelectedTags(filteredTags);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tags, resourceType, region, xFilter]);
+    }, [tags, resourceType, region]);
 
     return (
       <Autocomplete
@@ -132,30 +129,5 @@ export const CloudPulseTagsSelect = React.memo(
         value={selectedTags ?? []}
       />
     );
-  },
-  compareProps
+  }
 );
-
-function compareProps(
-  prevProps: CloudPulseTagsSelectProps,
-  nextProps: CloudPulseTagsSelectProps
-): boolean {
-  // these properties can be extended going forward
-  const keysToCompare: (keyof CloudPulseTagsSelectProps)[] = [
-    'region',
-    'resourceType',
-  ];
-
-  for (const key of keysToCompare) {
-    if (prevProps[key] !== nextProps[key]) {
-      return false;
-    }
-  }
-
-  if (!deepEqual(prevProps.xFilter, nextProps.xFilter)) {
-    return false;
-  }
-
-  // Ignore function props in comparison
-  return true;
-}

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -18,7 +18,7 @@ export interface CloudPulseTagsSelectProps {
   label: string;
   optional?: boolean;
   placeholder?: string;
-  region?: FilterValueType;
+  region: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
 }
@@ -40,7 +40,7 @@ export const CloudPulseTagsSelect = React.memo(
     const { data: linodes, isError, isLoading } = useAllLinodesQuery();
     // fetch all linode instances, consume the associated tags
     const tags = React.useMemo(() => {
-      if (!linodes) {
+      if (!linodes || !region) {
         return [];
       }
 

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -50,7 +50,7 @@ export const CloudPulseTagsSelect = React.memo(
     // fetch all linode instances, consume the associated tags
     const tags = React.useMemo(() => {
       if (!linodesByRegion) {
-        return [];
+        return undefined;
       }
 
       return Array.from(
@@ -65,20 +65,22 @@ export const CloudPulseTagsSelect = React.memo(
     const isAutocompleteOpen = React.useRef(false); // Ref to track the open state of Autocomplete
 
     React.useEffect(() => {
-      if (!tags || !savePreferences || !region) {
-        setSelectedTags([]);
-        handleTagsChange([]);
-        return;
+      if (!tags || !savePreferences || selectedTags) {
+        if (selectedTags) {
+          setSelectedTags([]);
+          handleTagsChange([]);
+        }
+      } else {
+        const defaultTags =
+          defaultValue && Array.isArray(defaultValue)
+            ? defaultValue.map((tag) => String(tag))
+            : [];
+        const filteredTags = tags.filter((tag) =>
+          defaultTags.includes(String(tag.label))
+        );
+        handleTagsChange(filteredTags);
+        setSelectedTags(filteredTags);
       }
-      const defaultTags =
-        defaultValue && Array.isArray(defaultValue)
-          ? defaultValue.map((tag) => String(tag))
-          : [];
-      const filteredTags = tags.filter((tag) =>
-        defaultTags.includes(String(tag.label))
-      );
-      handleTagsChange(filteredTags);
-      setSelectedTags(filteredTags);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tags, resourceType, region, xFilter]);
 
@@ -125,7 +127,7 @@ export const CloudPulseTagsSelect = React.memo(
         loading={isLoading}
         multiple
         noMarginTop
-        options={tags}
+        options={tags ?? []}
         placeholder={selectedTags?.length ? '' : placeholder || 'Select Tags'}
         value={selectedTags ?? []}
       />

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseTagsFilter.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import { themes } from 'src/utilities/theme';
 
+import type { FilterValueType } from '../Dashboard/CloudPulseDashboardLanding';
 import type { FilterValue, Linode } from '@linode/api-v4';
 
 export interface CloudPulseTags {
@@ -17,6 +18,7 @@ export interface CloudPulseTagsSelectProps {
   label: string;
   optional?: boolean;
   placeholder?: string;
+  region?: FilterValueType;
   resourceType: string | undefined;
   savePreferences?: boolean;
 }
@@ -25,10 +27,12 @@ export const CloudPulseTagsSelect = React.memo(
   (props: CloudPulseTagsSelectProps) => {
     const {
       defaultValue,
+      disabled,
       handleTagsChange,
       label,
       optional,
       placeholder,
+      region,
       resourceType,
       savePreferences,
     } = props;
@@ -39,12 +43,17 @@ export const CloudPulseTagsSelect = React.memo(
       if (!linodes) {
         return [];
       }
+
+      const linodesByRegion = linodes.filter(
+        (linode: Linode) => linode.region === region
+      ); // filter linodes by region to achieve tags by region
+
       return Array.from(
-        new Set(linodes.flatMap((linode: Linode) => linode.tags))
+        new Set(linodesByRegion.flatMap((linode: Linode) => linode.tags))
       )
         .sort()
         .map((tag) => ({ label: tag })) as CloudPulseTags[];
-    }, [linodes]);
+    }, [linodes, region]);
 
     const [selectedTags, setSelectedTags] = React.useState<CloudPulseTags[]>();
 
@@ -104,7 +113,7 @@ export const CloudPulseTagsSelect = React.memo(
         autoHighlight
         clearOnBlur
         data-testid="tags-select"
-        disabled={!resourceType}
+        disabled={disabled}
         errorText={isError ? `Failed to fetch ${label || 'Tags'}.` : ''}
         label={label || 'Tags'}
         limitTags={1}


### PR DESCRIPTION
## Description 📝
Updated the tags dependency and filtering based on region.

## Changes  🔄

List any change(s) relevant to the reviewer.
- Tags will be placed after region selection component.
- Tags will be in disabled state in case no region is selected. When a region is selected, tags will be filtered based on the region and listed in tags selection component.

_**Note: cypress changes required for this update.**_

## Target release date 🗓️
<>

## Preview 📷


https://github.com/user-attachments/assets/e5fea8ba-f745-4042-9ebd-25978f13aa7f





## How to test 🧪

### Verification steps

- Navigate to monitor tab.
- Select a dashboard. 
- Tags are in disabled state if no region is selected. Select any region, tags will be enabled and listed after being filtered based on the selected region.
- To verify if tags are filtered based on region, go to the /instances api call in network tab and see the tags associated with the selected region and see if all associated tags are listed in the dropdown. 
- Finally, select tag/tags, resources to visualize the metrics.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
---
