### PR TITLE
Pass implicit filter type dedicated / shared on Resources fetch based on Alert Details Response 

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -2,6 +2,7 @@ export type AlertSeverityType = 0 | 1 | 2 | 3;
 export type MetricAggregationType = 'avg' | 'sum' | 'min' | 'max' | 'count';
 export type MetricOperatorType = 'eq' | 'gt' | 'lt' | 'gte' | 'lte';
 export type AlertServiceType = 'linode' | 'dbaas';
+export type AlertClass = 'dedicated' | 'shared';
 export type DimensionFilterOperatorType =
   | 'eq'
   | 'neq'
@@ -236,6 +237,7 @@ export interface Alert {
   updated_by: string;
   created: string;
   updated: string;
+  class?: AlertClass;
 }
 
 interface NotificationChannelAlerts {

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -147,7 +147,7 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
     polling_interval_seconds: 120,
     trigger_occurrences: 3,
   },
-  type: 'user',
+  type: 'system',
   updated: new Date().toISOString(),
   updated_by: 'user1',
 });

--- a/packages/manager/src/factories/cloudpulse/alerts.ts
+++ b/packages/manager/src/factories/cloudpulse/alerts.ts
@@ -81,6 +81,7 @@ export const alertFactory = Factory.Sync.makeFactory<Alert>({
       url: '',
     },
   ],
+  class: 'dedicated',
   created: new Date().toISOString(),
   created_by: 'user1',
   description: 'Test description',

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -129,9 +129,7 @@ export const AlertDetail = () => {
           data-qa-section="Resources"
         >
           <AlertResources
-            alertClass={
-              alertDetails ? (alertClass ? alertClass : '') : undefined
-            }
+            alertClass={alertClass}
             alertResourceIds={entityIds}
             alertType={type}
             serviceType={serviceTypeObj}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -91,6 +91,7 @@ export const AlertDetail = () => {
     );
   }
   const {
+    class: alertClass,
     entity_ids: entityIds,
     service_type: serviceTypeObj,
     type,
@@ -128,10 +129,12 @@ export const AlertDetail = () => {
           data-qa-section="Resources"
         >
           <AlertResources
+            alertClass={
+              alertDetails ? (alertClass ? alertClass : '') : undefined
+            }
             alertResourceIds={entityIds}
             alertType={type}
             serviceType={serviceTypeObj}
-            alertClass={undefined}
           />
         </Box>
         <Box

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsDetail/AlertDetail.tsx
@@ -131,6 +131,7 @@ export const AlertDetail = () => {
             alertResourceIds={entityIds}
             alertType={type}
             serviceType={serviceTypeObj}
+            alertClass={undefined}
           />
         </Box>
         <Box

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
@@ -101,6 +101,10 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
   const [selectedOnly, setSelectedOnly] = React.useState<boolean>(false);
 
   const xFilterToBeApplied: Filter | undefined = React.useMemo(() => {
+    if (serviceType !== 'dbaas') {
+      return undefined;
+    }
+
     // If the serviceType is 'dbaas', always include the platform filter
     const platformFilter: Filter | undefined =
       serviceType === 'dbaas' ? { platform: 'rdbms-default' } : undefined;

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
@@ -138,7 +138,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
     }
 
     return undefined;
-  }, [alertClass, serviceType]);
+  }, [alertClass, alertType, serviceType]);
 
   const {
     data: regions,

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/AlertsResources.tsx
@@ -22,6 +22,7 @@ import { DisplayAlertResources } from './DisplayAlertResources';
 import type { AlertFilterKey, AlertFilterType } from './constants';
 import type { AlertInstance } from './DisplayAlertResources';
 import type {
+  AlertClass,
   AlertDefinitionType,
   AlertServiceType,
   Filter,
@@ -32,7 +33,7 @@ export interface AlertResourcesProp {
   /**
    * Class of the alert (dedicated / shared)
    */
-  alertClass?: string;
+  alertClass?: AlertClass;
   /**
    * The label of the alert to be displayed
    */
@@ -112,7 +113,7 @@ export const AlertResources = React.memo((props: AlertResourcesProp) => {
     // Apply type filter only for system alerts with a valid alertClass
     const typeFilter: Filter = {
       type: {
-        '+contains': alertClass === 'dedicated' ? 'dedicated' : 'shared',
+        '+contains': alertClass,
       },
     };
 

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsResources/constants.ts
@@ -1,9 +1,9 @@
-import { AlertServiceType } from '@linode/api-v4';
 import { engineTypeMap } from '../constants';
 import { AlertsEngineTypeFilter } from './AlertsEngineTypeFilter';
 
 import type { AlertsEngineOptionProps } from './AlertsEngineTypeFilter';
 import type { AlertInstance } from './DisplayAlertResources';
+import type { AlertServiceType } from '@linode/api-v4';
 import type { MemoExoticComponent } from 'react';
 
 interface ColumnConfig<T> {
@@ -12,10 +12,11 @@ interface ColumnConfig<T> {
   sortingKey?: keyof T;
 }
 
-type ServiceColumns<T> = Record<AlertServiceType | '', ColumnConfig<T>[]>;
+type ServiceColumns<T> = Record<'' | AlertServiceType, ColumnConfig<T>[]>;
 
 export const serviceTypeBasedColumns: ServiceColumns<AlertInstance> = {
-  '': [ // for empty case lets display resource and region
+  '': [
+    // for empty case lets display resource and region
     {
       accessor: ({ label }) => label,
       label: 'Resource',

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
@@ -56,7 +56,6 @@ export const CloudPulseModifyAlertResources = React.memo(
                     ? fieldState.error.message
                     : undefined
                 }
-                alertClass=""
                 alertResourceIds={field.value}
                 alertType="user"
                 handleResourcesSelection={handleResourcesSelection}

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Resources/CloudPulseModifyAlertResources.tsx
@@ -56,6 +56,7 @@ export const CloudPulseModifyAlertResources = React.memo(
                     ? fieldState.error.message
                     : undefined
                 }
+                alertClass=""
                 alertResourceIds={field.value}
                 alertType="user"
                 handleResourcesSelection={handleResourcesSelection}

--- a/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertResources.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/EditAlert/EditAlertResources.tsx
@@ -119,7 +119,13 @@ export const EditAlertResources = () => {
     setSelectedResources(resourceIds); // keep track of the selected resources and update it on save
   };
 
-  const { entity_ids, label, service_type, type } = alertDetails;
+  const {
+    class: alertClass,
+    entity_ids,
+    label,
+    service_type,
+    type,
+  } = alertDetails;
 
   return (
     <>
@@ -132,6 +138,7 @@ export const EditAlertResources = () => {
         }}
       >
         <AlertResources
+          alertClass={alertClass}
           alertLabel={label}
           alertResourceIds={entity_ids}
           alertType={type}


### PR DESCRIPTION
## Description 📝
Pass a type filter dedicated / shared while fetching resources based on alert details response for system alerts

## Changes  🔄

1. Pass type filter during the resources fetch call if the alert details api contains **class property** and it is of type **System**

## Target release date 🗓️
25-02-2025

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

1. Login and navigate to monitor without mocks and then to alerts
2. Open the alert details of alert **[High CPU Usage - Plan Dedicated](http://localhost:3000/monitor/alerts/definitions/detail/dbaas/5000)**
3. In the instances call in network tab, you will be able to see the type filter passed along with the platform filter
4. Same for edit flow as well for the same alert
5. Open another user alert and see the instances call, no type filter will be passed.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All unit tests are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
