### PR TITLE
upcoming:[DI-24467] - Update group_by type in widgets

### DIFF
--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -61,7 +61,7 @@ export interface Widgets {
   color: string;
   entity_ids: string[];
   filters: DimensionFilter[];
-  group_by: string;
+  group_by: string[];
   label: string;
   metric: string;
   namespace_id: number;
@@ -138,7 +138,7 @@ export interface CloudPulseMetricsRequest {
   absolute_time_duration: DateTimeWithPreset | undefined;
   entity_ids: number[];
   filters?: Filters[];
-  group_by: string;
+  group_by: string[];
   metrics: Metric[];
   relative_time_duration: TimeDuration | undefined;
   time_granularity: TimeGranularity | undefined;

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
@@ -65,7 +65,7 @@ const dashboard = dashboardFactory.build({
       metric: name,
       unit,
       y_label: yLabel,
-      group_by: ['entity_id'],
+      group_by: ['entity_id', 'node_type'],
     });
   }),
 });
@@ -190,7 +190,9 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
         expect(filtersStr).to.include('"dimension_label":"node_type"');
         expect(filtersStr).to.include('"operator":"eq"');
         expect(filtersStr).to.include('"value":"secondary"');
-        expect(group_by).to.deep.equal(['entity_id']);
+        expect(group_by.length).to.equal(2);
+        expect(group_by[0]).to.equal('entity_id');
+        expect(group_by[1]).to.equal('node_type');
       });
   });
 
@@ -272,7 +274,9 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
         expect(filtersStr).to.include('"dimension_label":"node_type"');
         expect(filtersStr).to.include('"operator":"eq"');
         expect(filtersStr).to.include('"value":"primary"');
-        expect(group_by).to.deep.equal(['entity_id']);
+        expect(group_by.length).to.equal(2);
+        expect(group_by[0]).to.equal('entity_id');
+        expect(group_by[1]).to.equal('node_type');
       });
   });
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
@@ -65,6 +65,7 @@ const dashboard = dashboardFactory.build({
       metric: name,
       unit,
       y_label: yLabel,
+      group_by: ['entity_id'],
     });
   }),
 });
@@ -189,7 +190,7 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
         expect(filtersStr).to.include('"dimension_label":"node_type"');
         expect(filtersStr).to.include('"operator":"eq"');
         expect(filtersStr).to.include('"value":"secondary"');
-        expect(group_by).to.equal('region');
+        expect(group_by).to.deep.equal(['entity_id']);
       });
   });
 
@@ -271,7 +272,7 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
         expect(filtersStr).to.include('"dimension_label":"node_type"');
         expect(filtersStr).to.include('"operator":"eq"');
         expect(filtersStr).to.include('"value":"primary"');
-        expect(group_by).to.equal('region');
+        expect(group_by).to.deep.equal(['entity_id']);
       });
   });
 

--- a/packages/manager/src/factories/dashboards.ts
+++ b/packages/manager/src/factories/dashboards.ts
@@ -41,7 +41,7 @@ export const widgetFactory = Factory.Sync.makeFactory<Widgets>({
   color: Factory.each((i) => color[i % color.length]),
   entity_ids: Factory.each((i) => [`resource-${i}`]),
   filters: dimensionFilterFactory.buildList(3),
-  group_by: 'region',
+  group_by: Factory.each((i) => [`group_by_${i}`]),
   label: Factory.each((i) => `widget_label_${i}`),
   metric: Factory.each((i) => `widget_metric_${i}`),
   namespace_id: Factory.each((i) => i % 10),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2792,6 +2792,7 @@ export const handlers = [
           metric: 'system_cpu_utilization_percent',
           size: 12,
           unit: '%',
+          group_by: ['entity_id'],
           y_label: 'system_cpu_utilization_ratio',
           filters: dimensionFilterFactory.buildList(5, {
             operator: pickRandom(['endswith', 'eq', 'neq', 'startswith']),
@@ -2805,6 +2806,7 @@ export const handlers = [
           metric: 'system_memory_usage_by_resource',
           size: 12,
           unit: 'Bytes',
+          group_by: ['entity_id'],
           y_label: 'system_memory_usage_bytes',
         },
         {
@@ -2816,6 +2818,7 @@ export const handlers = [
           size: 6,
           unit: 'Bytes',
           y_label: 'system_network_io_bytes_total',
+          group_by: ['entity_id'],
           filters: dimensionFilterFactory.buildList(3, {
             operator: pickRandom(['endswith', 'eq', 'neq', 'startswith']),
           }),
@@ -2828,6 +2831,7 @@ export const handlers = [
           metric: 'system_disk_OPS_total',
           size: 6,
           unit: 'OPS',
+          group_by: ['entity_id'],
           y_label: 'system_disk_operations_total',
         },
       ],


### PR DESCRIPTION
## Description 📝
Update group_by type in widgets.

## Changes  🔄
- Update `Widgets` and `CloudPulseMetricsRequest` in types.

## Target release date 🗓️
6 May 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| `group_by` wasn't showing up as it was undefined ![image](https://github.com/user-attachments/assets/cac31a0f-d8ad-4c83-a1c2-156a42cbcbf3) | group_by is defined and visible in paylaod ![image](https://github.com/user-attachments/assets/353c25ca-cccd-427d-a9f6-cac609843e80) |
|group_by is of string type ![image](https://github.com/user-attachments/assets/25836dbc-44a0-4e6e-ac61-2e0ce832af84) | group_by is of string[] type ![image](https://github.com/user-attachments/assets/8588d634-c385-4f65-9d43-3f6e49df3a44) |

## How to test 🧪

### Verification steps

(How to verify changes)

- Go to Metrics page, select filters.
- Go to networks tab and observe payload of `/metrics` call.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---