### PR TITLE
upcoming: [DI-24750] - Capability to delete user alert

### DIFF
--- a/packages/api-v4/src/cloudpulse/alerts.ts
+++ b/packages/api-v4/src/cloudpulse/alerts.ts
@@ -116,3 +116,11 @@ export const deleteEntityFromAlert = (
     ),
     setMethod('DELETE')
   );
+
+export const deleteAlertDefinition = (serviceType: string, alertId: number) =>
+  Request<Alert>(
+    setURL(
+      `${API_ROOT}/monitor/services/${encodeURIComponent(serviceType)}/alert-definitions/${encodeURIComponent(alertId)}`,
+    ),
+    setMethod('DELETE'),
+  );

--- a/packages/api-v4/src/cloudpulse/types.ts
+++ b/packages/api-v4/src/cloudpulse/types.ts
@@ -337,3 +337,8 @@ export interface EntityAlertUpdatePayload {
   entityId: string;
   alert: Alert;
 }
+
+export interface DeleteAlertPayload {
+  alertId: number;
+  serviceType: string;
+}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertActionMenu.tsx
@@ -8,6 +8,11 @@ import type { AlertDefinitionType, AlertStatusType } from '@linode/api-v4';
 
 export interface ActionHandlers {
   /**
+   * Callback for delete action
+   */
+  handleDelete: () => void;
+
+  /**
    * Callback for show details action
    */
   handleDetails: () => void;

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.test.tsx
@@ -10,11 +10,13 @@ import { AlertsListTable } from './AlertListTable';
 
 const queryMocks = vi.hoisted(() => ({
   useEditAlertDefinition: vi.fn(),
+  useDeleteAlertDefinitionMutation: vi.fn(),
 }));
 
 vi.mock('src/queries/cloudpulse/alerts', () => ({
   ...vi.importActual('src/queries/cloudpulse/alerts'),
   useEditAlertDefinition: queryMocks.useEditAlertDefinition,
+  useDeleteAlertDefinitionMutation: queryMocks.useDeleteAlertDefinitionMutation,
 }));
 
 queryMocks.useEditAlertDefinition.mockReturnValue({
@@ -23,6 +25,11 @@ queryMocks.useEditAlertDefinition.mockReturnValue({
   reset: vi.fn(),
 });
 const mockScroll = vi.fn();
+queryMocks.useDeleteAlertDefinitionMutation.mockReturnValue({
+  isError: false,
+  mutateAsync: vi.fn().mockResolvedValue({}),
+  reset: vi.fn(),
+});
 
 describe('Alert List Table test', () => {
   it('should render the alert landing table ', async () => {

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertListTable.tsx
@@ -83,11 +83,13 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
   const { mutateAsync: deleteAlertDefinition } =
     useDeleteAlertDefinitionMutation();
   const [selectedAlert, setSelectedAlert] = React.useState<Alert>({} as Alert);
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] =
-    React.useState<boolean>(false);
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
   const [isUpdating, setIsUpdating] = React.useState<boolean>(false);
-  const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
+
+  const [deleteState, setDeleteState] = React.useState({
+    isDialogOpen: false,
+    isDeleting: false,
+  });
 
   const handleDetails = ({ id: _id, service_type: serviceType }: Alert) => {
     history.push(`${location.pathname}/detail/${serviceType}/${_id}`);
@@ -108,7 +110,7 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
 
   const handleDelete = React.useCallback((alert: Alert) => {
     setSelectedAlert(alert);
-    setIsDeleteDialogOpen(true);
+    setDeleteState((prev) => ({ ...prev, isDialogOpen: true }));
   }, []);
 
   const handleConfirm = React.useCallback(
@@ -151,7 +153,8 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
         serviceType: alert.service_type,
         alertId: alert.id,
       };
-      setIsDeleting(true);
+      setDeleteState((prev) => ({ ...prev, isDeleting: true }));
+
       deleteAlertDefinition(payload)
         .then(() => {
           enqueueSnackbar('Alert deleted', { variant: 'success' });
@@ -161,13 +164,10 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
             deleteError,
             'Alert deletion failed.'
           );
-          enqueueSnackbar(errorResponse[0].reason, {
-            variant: 'error',
-          });
+          enqueueSnackbar(errorResponse[0].reason, { variant: 'error' });
         })
         .finally(() => {
-          setIsDeleteDialogOpen(false);
-          setIsDeleting(false);
+          setDeleteState({ isDialogOpen: false, isDeleting: false });
         });
     },
     [deleteAlertDefinition]
@@ -315,10 +315,12 @@ export const AlertsListTable = React.memo((props: AlertsListTableProps) => {
       <DeletionDialog
         entity="Alert"
         label={selectedAlert.label}
-        loading={isDeleting}
-        onClose={() => setIsDeleteDialogOpen(false)}
+        loading={deleteState.isDeleting}
+        onClose={() =>
+          setDeleteState((prev) => ({ ...prev, isDialogOpen: false }))
+        }
         onDelete={() => handleDeleteConfirm(selectedAlert)}
-        open={isDeleteDialogOpen}
+        open={deleteState.isDialogOpen}
       />
     </>
   );

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -1,4 +1,5 @@
 import { capitalize } from '@linode/utilities';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import * as React from 'react';
@@ -28,12 +29,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build();
     const renderedAlert = (
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -45,12 +47,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ status: 'enabled' });
     const renderedAlert = (
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -72,12 +75,13 @@ describe('Alert Row', () => {
     const renderedAlert = (
       <Router history={history}>
         <AlertTableRow
+          alert={alert}
           handlers={{
+            handleDelete: vi.fn(),
             handleDetails: vi.fn(),
             handleEdit: vi.fn(),
             handleStatusChange: vi.fn(),
           }}
-          alert={alert}
           services={mockServices}
         />
       </Router>
@@ -92,12 +96,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ status: 'enabled' });
     const { getAllByLabelText, getByTestId } = renderWithTheme(
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -112,12 +117,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ status: 'disabled', type: 'user' });
     const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -130,12 +136,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ type: 'user' });
     const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -148,12 +155,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ status: 'in progress', type: 'user' });
     const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -170,12 +178,13 @@ describe('Alert Row', () => {
     const alert = alertFactory.build({ status: 'in progress', type: 'user' });
     const { getByLabelText, getByText } = renderWithTheme(
       <AlertTableRow
+        alert={alert}
         handlers={{
+          handleDelete: vi.fn(),
           handleDetails: vi.fn(),
           handleEdit: vi.fn(),
           handleStatusChange: vi.fn(),
         }}
-        alert={alert}
         services={mockServices}
       />
     );
@@ -186,5 +195,26 @@ describe('Alert Row', () => {
       'aria-disabled',
       'true'
     );
+  });
+
+  it('should show the delete action item for the user alert', async () => {
+    const alert = alertFactory.build({ type: 'user' });
+    renderWithTheme(
+      <AlertTableRow
+        alert={alert}
+        handlers={{
+          handleDelete: vi.fn(),
+          handleDetails: vi.fn(),
+          handleEdit: vi.fn(),
+          handleStatusChange: vi.fn(),
+        }}
+        services={mockServices}
+      />
+    );
+    const ActionMenu = screen.getByLabelText(
+      `Action menu for Alert ${alert.label}`
+    );
+    await userEvent.click(ActionMenu);
+    expect(screen.getByText('Delete')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertTableRow.test.tsx
@@ -215,6 +215,6 @@ describe('Alert Row', () => {
       `Action menu for Alert ${alert.label}`
     );
     await userEvent.click(ActionMenu);
-    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeVisible();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertsTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/AlertsTable.tsx
@@ -13,6 +13,10 @@ interface UngroupedAlertsProps {
    */
   alerts: Alert[];
   /**
+   * Callback function to handle deleting an alert
+   */
+  handleDelete: (alert: Alert) => void;
+  /**
    * Callback function to handle viewing alert details
    */
   handleDetails: (alert: Alert) => void;
@@ -35,18 +39,20 @@ export const AlertsTable = ({
   handleDetails,
   handleEdit,
   handleStatusChange,
+  handleDelete,
   services,
 }: UngroupedAlertsProps) => {
   return (
     <TableBody>
       {alerts.map((alert: Alert) => (
         <AlertTableRow
+          alert={alert}
           handlers={{
             handleDetails: () => handleDetails(alert),
             handleEdit: () => handleEdit(alert),
             handleStatusChange: () => handleStatusChange(alert),
+            handleDelete: () => handleDelete(alert),
           }}
-          alert={alert}
           key={alert.id}
           services={services}
         />

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../Utils/AlertResourceUtils', () => ({
 const mockHandleDetails = vi.fn();
 const mockHandleEdit = vi.fn();
 const mockHandleStatusChange = vi.fn();
+const mockHandleDelete = vi.fn();
 
 const mockServices: Item<string, AlertServiceType>[] = [
   { label: 'Linode', value: 'linode' },
@@ -42,6 +43,7 @@ describe('GroupedAlertsTable', () => {
     const { getByText } = renderWithTheme(
       <GroupedAlertsTable
         groupedAlerts={mockAlerts}
+        handleDelete={mockHandleDelete}
         handleDetails={mockHandleDetails}
         handleEdit={mockHandleEdit}
         handleStatusChange={mockHandleStatusChange}
@@ -69,6 +71,7 @@ describe('GroupedAlertsTable', () => {
     const { getByRole } = renderWithTheme(
       <GroupedAlertsTable
         groupedAlerts={alerts}
+        handleDelete={mockHandleDelete}
         handleDetails={mockHandleDetails}
         handleEdit={mockHandleEdit}
         handleStatusChange={mockHandleStatusChange}
@@ -94,6 +97,7 @@ describe('GroupedAlertsTable', () => {
     const { container, getByRole } = renderWithTheme(
       <GroupedAlertsTable
         groupedAlerts={manyAlerts}
+        handleDelete={mockHandleDelete}
         handleDetails={mockHandleDetails}
         handleEdit={mockHandleEdit}
         handleStatusChange={mockHandleStatusChange}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.tsx
@@ -35,6 +35,10 @@ interface GroupedAlertsProps {
    */
   handleStatusChange: (alert: Alert) => void;
   /**
+   * Callback function to handle deleting an alert
+   */
+  handleDelete: (alert: Alert) => void;
+  /**
    * The list of services to display in the table
    */
   services: Item<string, AlertServiceType>[];
@@ -45,6 +49,7 @@ export const GroupedAlertsTable = ({
   handleDetails,
   handleEdit,
   handleStatusChange,
+  handleDelete,
   services,
 }: GroupedAlertsProps) => {
   const theme = useTheme();
@@ -98,6 +103,7 @@ export const GroupedAlertsTable = ({
                       handleDetails: () => handleDetails(alert),
                       handleEdit: () => handleEdit(alert),
                       handleStatusChange: () => handleStatusChange(alert),
+                      handleDelete: () => handleDelete(alert),
                     }}
                     alert={alert}
                     key={alert.id}

--- a/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/AlertsListing/GroupedAlertsTable.tsx
@@ -23,6 +23,10 @@ interface GroupedAlertsProps {
    */
   groupedAlerts: GroupedBy<Alert>;
   /**
+   * Callback function to handle deleting an alert
+   */
+  handleDelete: (alert: Alert) => void;
+  /**
    * Callback function to handle viewing alert details
    */
   handleDetails: (alert: Alert) => void;
@@ -34,10 +38,6 @@ interface GroupedAlertsProps {
    *  Callback function to handle enabling or disabling an alert
    */
   handleStatusChange: (alert: Alert) => void;
-  /**
-   * Callback function to handle deleting an alert
-   */
-  handleDelete: (alert: Alert) => void;
   /**
    * The list of services to display in the table
    */
@@ -99,13 +99,13 @@ export const GroupedAlertsTable = ({
                 </StyledTagHeaderRow>
                 {paginatedTagAlerts.map((alert) => (
                   <AlertTableRow
+                    alert={alert}
                     handlers={{
                       handleDetails: () => handleDetails(alert),
                       handleEdit: () => handleEdit(alert),
                       handleStatusChange: () => handleStatusChange(alert),
                       handleDelete: () => handleDelete(alert),
                     }}
-                    alert={alert}
                     key={alert.id}
                     services={services}
                   />
@@ -114,6 +114,8 @@ export const GroupedAlertsTable = ({
                   <TableRow>
                     <TableCell colSpan={7} sx={{ padding: 0 }}>
                       <PaginationFooter
+                        count={count}
+                        eventCategory={`Alert Definitions Table ${tag}`}
                         handlePageChange={(newPage) => {
                           handleTagPageChange(newPage);
                           scrollToTagWithAnimation(tag);
@@ -123,6 +125,8 @@ export const GroupedAlertsTable = ({
                           handleTagPageChange(1);
                           scrollToTagWithAnimation(tag);
                         }}
+                        page={page}
+                        pageSize={pageSize}
                         sx={{
                           border: 0,
                           marginBottom:
@@ -131,10 +135,6 @@ export const GroupedAlertsTable = ({
                               : theme.spacingFunction(16),
                           marginTop: theme.spacingFunction(16),
                         }}
-                        count={count}
-                        eventCategory={`Alert Definitions Table ${tag}`}
-                        page={page}
-                        pageSize={pageSize}
                       />
                     </TableCell>
                   </TableRow>

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -47,7 +47,8 @@ export const getAlertTypeToActionsList = (
     },
     {
       disabled:
-        true /* TODO: add proper condition check to disable delete once the API's are available*/,
+        /* Hardcoding it to be disabled for now as the API's are not ready yet, once they're available will add proper condition check for the delete action */
+        true,
       onClick: handleDelete,
       title: 'Delete',
     },

--- a/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
+++ b/packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts
@@ -8,11 +8,18 @@ import type { Action } from 'src/components/ActionMenu/ActionMenu';
  * @param onClickHandlers The list of handlers required to be called on click of an action
  * @returns The actions based on the type of the alert
  */
+
 export const getAlertTypeToActionsList = (
-  { handleDetails, handleEdit, handleStatusChange }: ActionHandlers,
+  {
+    handleDetails,
+    handleEdit,
+    handleStatusChange,
+    handleDelete,
+  }: ActionHandlers,
   alertStatus: AlertStatusType
 ): Record<AlertDefinitionType, Action[]> => ({
   // for now there is system and user alert types, in future more alert types can be added and action items will differ according to alert types
+
   system: [
     {
       onClick: handleDetails,
@@ -37,6 +44,12 @@ export const getAlertTypeToActionsList = (
       disabled: alertStatus === 'in progress' || alertStatus === 'failed',
       onClick: handleStatusChange,
       title: getTitleForStatusChange(alertStatus),
+    },
+    {
+      disabled:
+        true /* TODO: add proper condition check to disable delete once the API's are available*/,
+      onClick: handleDelete,
+      title: 'Delete',
     },
   ],
 });

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2466,27 +2466,27 @@ export const handlers = [
 
     return HttpResponse.json(response);
   }),
-    http.post(
-      '*/monitor/services/:service_type/alert-definitions',
-      async ({ request }) => {
-  
-        const types: AlertDefinitionType[] = ['system', 'user'];
-        const status: AlertStatusType[] = ['enabled', 'disabled'];
-        const severity: AlertSeverityType[] = [0, 1, 2, 3];
-        const users = ['user1', 'user2', 'user3'];
-        const serviceTypes: AlertServiceType[] = ['linode', 'dbaas'];
-        const reqBody = await request.json();
-        const response = alertFactory.build({
-          ...(reqBody as CreateAlertDefinitionPayload),
-          created_by: pickRandom(users),
-          service_type: pickRandom(serviceTypes),
-          severity: pickRandom(severity),
-          status: pickRandom(status),
-          type: pickRandom(types),
-          updated_by: pickRandom(users),
-        });
-        return HttpResponse.json(response);
-  }),
+  http.post(
+    '*/monitor/services/:service_type/alert-definitions',
+    async ({ request }) => {
+      const types: AlertDefinitionType[] = ['system', 'user'];
+      const status: AlertStatusType[] = ['enabled', 'disabled'];
+      const severity: AlertSeverityType[] = [0, 1, 2, 3];
+      const users = ['user1', 'user2', 'user3'];
+      const serviceTypes: AlertServiceType[] = ['linode', 'dbaas'];
+      const reqBody = await request.json();
+      const response = alertFactory.build({
+        ...(reqBody as CreateAlertDefinitionPayload),
+        created_by: pickRandom(users),
+        service_type: pickRandom(serviceTypes),
+        severity: pickRandom(severity),
+        status: pickRandom(status),
+        type: pickRandom(types),
+        updated_by: pickRandom(users),
+      });
+      return HttpResponse.json(response);
+    }
+  ),
   http.get(
     '*/monitor/services/:serviceType/alert-definitions',
     async ({ params }) => {
@@ -2607,6 +2607,9 @@ export const handlers = [
     return HttpResponse.json(
       makeResourcePage(notificationChannelFactory.buildList(7))
     );
+  }),
+  http.delete('*/monitor/services/:serviceType/alert-definitions/:id', () => {
+    return HttpResponse.json({});
   }),
   http.get('*/monitor/services', () => {
     const response: ServiceTypesList = {

--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -4,6 +4,7 @@ import {
   deleteEntityFromAlert,
   editAlertDefinition,
 } from '@linode/api-v4/lib/cloudpulse';
+import { deleteAlertDefinition } from '@linode/api-v4/lib/cloudpulse';
 import { queryPresets } from '@linode/queries';
 import {
   keepPreviousData,
@@ -22,7 +23,12 @@ import type {
   EntityAlertUpdatePayload,
   NotificationChannel,
 } from '@linode/api-v4/lib/cloudpulse';
-import type { APIError, Filter, Params } from '@linode/api-v4/lib/types';
+import type {
+  APIError,
+  DeleteAlertPayload,
+  Filter,
+  Params,
+} from '@linode/api-v4/lib/types';
 
 export const useCreateAlertDefinition = (serviceType: AlertServiceType) => {
   const queryClient = useQueryClient();
@@ -197,6 +203,30 @@ export const useRemoveEntityFromAlert = () => {
 
       queryClient.invalidateQueries({
         queryKey: queryFactory.alerts._ctx.all().queryKey,
+      });
+    },
+  });
+};
+
+export const useDeleteAlertDefinitionMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Alert, APIError[], DeleteAlertPayload>({
+    mutationFn: ({ serviceType, alertId }) => {
+      return deleteAlertDefinition(serviceType, alertId);
+    },
+    onSuccess(_data, { serviceType, alertId }) {
+      queryClient.invalidateQueries({
+        queryKey: queryFactory.alerts._ctx.all().queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey:
+          queryFactory.alerts._ctx.alertsByServiceType(serviceType).queryKey,
+      });
+      queryClient.removeQueries({
+        queryKey: queryFactory.alerts._ctx.alertByServiceTypeAndId(
+          serviceType,
+          String(alertId)
+        ).queryKey,
       });
     },
   });


### PR DESCRIPTION
## Description 📝
Feature for user to delete an user alert from the action menu

## Changes  🔄

List any change(s) relevant to the reviewer.

- Added Delete option to the ActionMenu handlers
- Added API Request to handle the deletion 
- Added `handleDelete` methods to trigger the confirmation box for the Deletion
- Relevant test cases to check for deletion.
- Mock response to the delete alert endpoint

## How to test 🧪
### Prerequisites

(How to setup test environment)

- In `packages/manager/src/features/CloudPulse/Alerts/Utils/AlertsActionMenu.ts` change the true to false to enable the delete action
 ```tsx
    {
      disabled:
       false /* TODO: add proper condition check to disable delete once the API's are available*/,
      onClick: handleDelete,
      title: 'Delete',
    },
```

## Preview 📷
| UX Mockups | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/b5148e84-962c-4824-aaa0-5122794b8e5d) | ![Screenshot 2025-04-24 at 14 36 15](https://github.com/user-attachments/assets/994ad401-be54-4077-80c3-9f894f058b48)|


<video src="https://github.com/user-attachments/assets/e36c95a1-7a8b-4f20-9806-141211d7a4c1" />


<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
