### PR TITLE
upcoming:[DI-24897] - Remove metric name from title conditionally

### DIFF
--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -66,6 +66,7 @@ describe('getLabelName method', () => {
     resources: [{ id: '123', label: 'linode-1' }],
     serviceType: 'linode',
     unit: '%',
+    isSingleUniqueMetricName: true,
   };
 
   it('returns resource label when all data is valid', () => {
@@ -140,6 +141,7 @@ it('test generateGraphData with metrics data', () => {
 
 describe('getDimensionName method', () => {
   const baseProps = {
+    isSingleUniqueMetricName: true,
     metric: { entity_id: '123' },
     resources: [{ id: '123', label: 'linode-1' }],
   };
@@ -167,13 +169,23 @@ describe('getDimensionName method', () => {
     expect(result).toBe('123');
   });
 
-  it('joins multiple metric values with separator', () => {
+  it('joins multiple metric values with separator excluding metric_name when there is only one unique metric name', () => {
     const props = {
       ...baseProps,
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
     };
     const result = getDimensionName(props);
     expect(result).toBe('linode-1 | primary-1');
+  });
+
+  it('joins multiple metric values with separator including metric_name when there are mumtiple unique metric names across metrics', () => {
+    const props = {
+      ...baseProps,
+      metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
+      isSingleUniqueMetricName: false,
+    };
+    const result = getDimensionName(props);
+    expect(result).toBe('linode-1 | test | primary-1');
   });
 
   it('handles empty metric values by filtering them out', () => {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -178,7 +178,7 @@ describe('getDimensionName method', () => {
     expect(result).toBe('linode-1 | primary-1');
   });
 
-  it('joins multiple metric values with separator including metric_name when there are mumtiple unique metric names across metrics', () => {
+  it('joins multiple metric values with separator including metric_name when there are multiple unique metric names', () => {
     const props = {
       ...baseProps,
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -66,7 +66,6 @@ describe('getLabelName method', () => {
     resources: [{ id: '123', label: 'linode-1' }],
     serviceType: 'linode',
     unit: '%',
-    hideMetricName: true,
   };
 
   it('returns resource label when all data is valid', () => {
@@ -141,7 +140,6 @@ it('test generateGraphData with metrics data', () => {
 
 describe('getDimensionName method', () => {
   const baseProps = {
-    hideMetricName: true,
     metric: { entity_id: '123' },
     resources: [{ id: '123', label: 'linode-1' }],
   };
@@ -173,6 +171,7 @@ describe('getDimensionName method', () => {
     const props = {
       ...baseProps,
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
+      hideMetricName: true,
     };
     const result = getDimensionName(props);
     expect(result).toBe('linode-1 | primary-1');
@@ -182,7 +181,6 @@ describe('getDimensionName method', () => {
     const props = {
       ...baseProps,
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
-      hideMetricName: false,
     };
     const result = getDimensionName(props);
     expect(result).toBe('linode-1 | test | primary-1');

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -173,7 +173,7 @@ describe('getDimensionName method', () => {
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
     };
     const result = getDimensionName(props);
-    expect(result).toBe('linode-1 | test | primary-1');
+    expect(result).toBe('linode-1 | primary-1');
   });
 
   it('handles empty metric values by filtering them out', () => {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -66,7 +66,7 @@ describe('getLabelName method', () => {
     resources: [{ id: '123', label: 'linode-1' }],
     serviceType: 'linode',
     unit: '%',
-    isSingleUniqueMetricName: true,
+    hideMetricName: true,
   };
 
   it('returns resource label when all data is valid', () => {
@@ -141,7 +141,7 @@ it('test generateGraphData with metrics data', () => {
 
 describe('getDimensionName method', () => {
   const baseProps = {
-    isSingleUniqueMetricName: true,
+    hideMetricName: true,
     metric: { entity_id: '123' },
     resources: [{ id: '123', label: 'linode-1' }],
   };
@@ -182,7 +182,7 @@ describe('getDimensionName method', () => {
     const props = {
       ...baseProps,
       metric: { entity_id: '123', metric_name: 'test', node_id: 'primary-1' },
-      isSingleUniqueMetricName: false,
+      hideMetricName: false,
     };
     const result = getDimensionName(props);
     expect(result).toBe('linode-1 | test | primary-1');

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -28,6 +28,11 @@ import type { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay'
 
 interface LabelNameOptionsProps {
   /**
+   * Boolean to check if there is only one unique metric name
+   */
+  isSingleUniqueMetricName: boolean;
+
+  /**
    * label for the graph title
    */
   label: string;
@@ -99,6 +104,11 @@ interface MetricRequestProps {
 
 interface DimensionNameProperties {
   /**
+   * Boolean to check if there is only one unique metric name
+   */
+  isSingleUniqueMetricName: boolean;
+
+  /**
    * metric key-value to generate dimension name
    */
   metric: { [label: string]: string };
@@ -141,6 +151,12 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
   const dimension: { [timestamp: number]: { [label: string]: number } } = {};
   const areas: AreaProps[] = [];
   const colors = Object.values(Alias.Chart.Categorical);
+
+  // check if there is only one unique metric name
+  const isSingleUniqueMetricName =
+    new Set(metricsList?.data?.result?.map((obj) => obj.metric.metric_name))
+      .size === 1;
+
   if (status === 'success') {
     metricsList?.data?.result?.forEach(
       (graphData: CloudPulseMetricsList, index) => {
@@ -165,6 +181,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
           metric: transformedData.metric,
           resources,
           unit,
+          isSingleUniqueMetricName,
         };
         const labelName = getLabelName(labelOptions);
         const data = seriesDataFormatter(transformedData.values, start, end);
@@ -285,14 +302,14 @@ export const getCloudPulseMetricRequest = (
  * @returns generated label name for graph dimension
  */
 export const getLabelName = (props: LabelNameOptionsProps): string => {
-  const { label, metric, resources, unit } = props;
+  const { label, metric, resources, unit, isSingleUniqueMetricName } = props;
   // aggregated metric, where metric keys will be 0
   if (!Object.keys(metric).length) {
     // in this case return widget label and unit
     return `${label} (${unit})`;
   }
 
-  return getDimensionName({ metric, resources });
+  return getDimensionName({ metric, resources, isSingleUniqueMetricName });
 };
 
 /**
@@ -301,14 +318,14 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
  */
 // ... existing code ...
 export const getDimensionName = (props: DimensionNameProperties): string => {
-  const { metric, resources } = props;
+  const { metric, resources, isSingleUniqueMetricName } = props;
   return Object.entries(metric)
     .map(([key, value]) => {
       if (key === 'entity_id') {
         return mapResourceIdToName(value, resources);
       }
 
-      if (key === 'metric_name') {
+      if (key === 'metric_name' && isSingleUniqueMetricName) {
         return '';
       }
 

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -155,7 +155,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
   // check whether to hide metric name or not based on the number of unique metric names
   const hideMetricName =
     new Set(metricsList?.data?.result?.map((obj) => obj.metric.metric_name))
-      .size === 1;
+      .size <= 1;
 
   if (status === 'success') {
     metricsList?.data?.result?.forEach(

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -30,7 +30,7 @@ interface LabelNameOptionsProps {
   /**
    * Boolean to check if metric name should be hidden
    */
-  hideMetricName: boolean;
+  hideMetricName?: boolean;
 
   /**
    * label for the graph title
@@ -106,7 +106,7 @@ interface DimensionNameProperties {
   /**
    * Boolean to check if metric name should be hidden
    */
-  hideMetricName: boolean;
+  hideMetricName?: boolean;
 
   /**
    * metric key-value to generate dimension name
@@ -154,7 +154,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
 
   // check whether to hide metric name or not based on the number of unique metric names
   const hideMetricName =
-    new Set(metricsList?.data?.result?.map((obj) => obj.metric.metric_name))
+    new Set(metricsList?.data?.result?.map(({ metric }) => metric.metric_name))
       .size <= 1;
 
   if (status === 'success') {
@@ -302,7 +302,7 @@ export const getCloudPulseMetricRequest = (
  * @returns generated label name for graph dimension
  */
 export const getLabelName = (props: LabelNameOptionsProps): string => {
-  const { label, metric, resources, unit, hideMetricName } = props;
+  const { label, metric, resources, unit, hideMetricName = false } = props;
   // aggregated metric, where metric keys will be 0
   if (!Object.keys(metric).length) {
     // in this case return widget label and unit
@@ -318,7 +318,7 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
  */
 // ... existing code ...
 export const getDimensionName = (props: DimensionNameProperties): string => {
-  const { metric, resources, hideMetricName } = props;
+  const { metric, resources, hideMetricName = false } = props;
   return Object.entries(metric)
     .map(([key, value]) => {
       if (key === 'entity_id') {

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -28,9 +28,9 @@ import type { MetricsDisplayRow } from 'src/components/LineGraph/MetricsDisplay'
 
 interface LabelNameOptionsProps {
   /**
-   * Boolean to check if there is only one unique metric name
+   * Boolean to check if metric name should be hidden
    */
-  isSingleUniqueMetricName: boolean;
+  hideMetricName: boolean;
 
   /**
    * label for the graph title
@@ -104,9 +104,9 @@ interface MetricRequestProps {
 
 interface DimensionNameProperties {
   /**
-   * Boolean to check if there is only one unique metric name
+   * Boolean to check if metric name should be hidden
    */
-  isSingleUniqueMetricName: boolean;
+  hideMetricName: boolean;
 
   /**
    * metric key-value to generate dimension name
@@ -152,8 +152,8 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
   const areas: AreaProps[] = [];
   const colors = Object.values(Alias.Chart.Categorical);
 
-  // check if there is only one unique metric name
-  const isSingleUniqueMetricName =
+  // check whether to hide metric name or not based on the number unique metric names
+  const hideMetricName =
     new Set(metricsList?.data?.result?.map((obj) => obj.metric.metric_name))
       .size === 1;
 
@@ -181,7 +181,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
           metric: transformedData.metric,
           resources,
           unit,
-          isSingleUniqueMetricName,
+          hideMetricName,
         };
         const labelName = getLabelName(labelOptions);
         const data = seriesDataFormatter(transformedData.values, start, end);
@@ -302,14 +302,14 @@ export const getCloudPulseMetricRequest = (
  * @returns generated label name for graph dimension
  */
 export const getLabelName = (props: LabelNameOptionsProps): string => {
-  const { label, metric, resources, unit, isSingleUniqueMetricName } = props;
+  const { label, metric, resources, unit, hideMetricName } = props;
   // aggregated metric, where metric keys will be 0
   if (!Object.keys(metric).length) {
     // in this case return widget label and unit
     return `${label} (${unit})`;
   }
 
-  return getDimensionName({ metric, resources, isSingleUniqueMetricName });
+  return getDimensionName({ metric, resources, hideMetricName });
 };
 
 /**
@@ -318,14 +318,14 @@ export const getLabelName = (props: LabelNameOptionsProps): string => {
  */
 // ... existing code ...
 export const getDimensionName = (props: DimensionNameProperties): string => {
-  const { metric, resources, isSingleUniqueMetricName } = props;
+  const { metric, resources, hideMetricName } = props;
   return Object.entries(metric)
     .map(([key, value]) => {
       if (key === 'entity_id') {
         return mapResourceIdToName(value, resources);
       }
 
-      if (key === 'metric_name' && isSingleUniqueMetricName) {
+      if (key === 'metric_name' && hideMetricName) {
         return '';
       }
 

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -308,6 +308,10 @@ export const getDimensionName = (props: DimensionNameProperties): string => {
         return mapResourceIdToName(value, resources);
       }
 
+      if (key === 'metric_name') {
+        return '';
+      }
+
       return value ?? '';
     })
     .filter(Boolean)

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -152,7 +152,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
   const areas: AreaProps[] = [];
   const colors = Object.values(Alias.Chart.Categorical);
 
-  // check whether to hide metric name or not based on the number unique metric names
+  // check whether to hide metric name or not based on the number of unique metric names
   const hideMetricName =
     new Set(metricsList?.data?.result?.map((obj) => obj.metric.metric_name))
       .size === 1;


### PR DESCRIPTION
## Description 📝

Remove metric name from legend title conditionally.


## Changes  🔄

- Remove metric name from legend title in `CloudPulseWidgetUtils.ts` when number of unique metric names in response of `/metrics` api call is <=1, else show.
- Update and add unit tests.

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/4a46fc88-38da-45a9-822b-f775d9de5a81) | ![image](https://github.com/user-attachments/assets/f5bb6448-05c0-49fc-81b6-cecd862200c0) |
| ![image](https://github.com/user-attachments/assets/800b6443-0920-4905-96cb-2a095c22fcfa) | ![image](https://github.com/user-attachments/assets/800b6443-0920-4905-96cb-2a095c22fcfa) |
| ![image](https://github.com/user-attachments/assets/4c95e554-815e-49e3-83cc-6cbdf93eca03) | ![image](https://github.com/user-attachments/assets/e2f21383-667e-4c52-92a1-8a799f0e23c4) |

## How to test 🧪

### Verification steps

(How to verify changes)

- Navigate to metrics page,
- Select all the filters.(Ex - dbaas, engine type, region, database clusters, node type).
- Open networks tab in chrome dev tools, observe the response of any `/metrics` api request.
- Verify that the legend row titles in metrics page don't contain the `metric_name` value coming from response of `/metrics` api call if there is only one unique metric_name present in response across all metric objects combined.
- Verify that the legend row titles in metrics page contain the `metric_name` value coming from response of `/metrics` api call if there are multiple unique `metric_name`s present in response across all metric objects combined.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---