### PR TITLE
Fix:[DI-25092] - Zoom tooltip show/no-show

### DIFF
--- a/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/Zoomer.tsx
@@ -17,7 +17,11 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
 
   if (props.zoomIn) {
     return (
-      <CloudPulseTooltip placement="bottom-end" title="Minimize">
+      <CloudPulseTooltip
+        key="minimize-tooltip"
+        placement="bottom-end"
+        title="Minimize"
+      >
         <IconButton
           aria-label="Zoom Out"
           color="inherit"
@@ -34,7 +38,11 @@ export const ZoomIcon = React.memo((props: ZoomIconProperties) => {
   }
 
   return (
-    <CloudPulseTooltip placement="bottom-end" title="Maximize">
+    <CloudPulseTooltip
+      key="maximize-tooltip"
+      placement="bottom-end"
+      title="Maximize"
+    >
       <IconButton
         aria-label="Zoom In"
         color="inherit"


### PR DESCRIPTION
## Description 📝

Zoom tooltip show/no-show bug fix, this bug is a side effect of mui tooltip.

## Changes  🔄

- Tooltip text should only show on hover and if any underlying element gets resized or get its position changed -subsequently changing position of zoom icon, tooltip text should not appear until next hover.

## Target release date 🗓️

20 May 2025

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/d9d669a4-6bd1-4da5-bf1a-f437438f053f) | ![image](https://github.com/user-attachments/assets/349777ca-6fe4-45ac-bbfc-e9a72df27ce6) |

Bug video before fix: 

https://github.com/user-attachments/assets/5f710f30-b09f-478f-83c5-9a2202eee068

## How to test 🧪

### Verification steps

(How to verify changes)

- Navigate to metrics page.
- Hover over the zoom icon and verify appearance of tooltip text.
- Click on zoom toggle button, verify non-appearance of tooltip text after the click, given that cursor is not on any zoom button.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>

---