### PR TITLE
upcoming: [DI-24902] - Reverting back LD flag changes for alerting time options

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/create-alert-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-alert-linode.spec.ts
@@ -46,13 +46,7 @@ export interface MetricDetails {
   threshold: string;
 }
 
-const flags: Partial<Flags> = {
-  aclp: { beta: true, enabled: true },
-  aclpAlertingTimeOptions: {
-    evaluationPeriodOptions: [{ label: '5 min', value: 300 }],
-    pollingIntervalOptions: [{ label: '5 min', value: 300 }],
-  },
-};
+const flags: Partial<Flags> = { aclp: { beta: true, enabled: true } };
 
 // Create mock data
 const mockAccount = accountFactory.build();

--- a/packages/manager/cypress/e2e/core/cloudpulse/create-linode-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-linode-alert.spec.ts
@@ -45,13 +45,7 @@ export interface MetricDetails {
   ruleIndex: number;
   threshold: string;
 }
-const flags: Partial<Flags> = {
-  aclp: { beta: true, enabled: true },
-  aclpAlertingTimeOptions: {
-    evaluationPeriodOptions: [{ label: '5 min', value: 300 }],
-    pollingIntervalOptions: [{ label: '5 min', value: 300 }],
-  },
-};
+const flags: Partial<Flags> = { aclp: { beta: true, enabled: true } };
 // Create mock data
 const mockAccount = accountFactory.build();
 const mockRegion = regionFactory.build({

--- a/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/create-user-alert.spec.ts
@@ -43,13 +43,7 @@ export interface MetricDetails {
   threshold: string;
 }
 
-const flags: Partial<Flags> = {
-  aclp: { beta: true, enabled: true },
-  aclpAlertingTimeOptions: {
-    evaluationPeriodOptions: [{ label: '5 min', value: 300 }],
-    pollingIntervalOptions: [{ label: '5 min', value: 300 }],
-  },
-};
+const flags: Partial<Flags> = { aclp: { beta: true, enabled: true } };
 
 // Create mock data
 const mockAccount = accountFactory.build();

--- a/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/edit-user-alert.spec.ts
@@ -46,13 +46,7 @@ import type { Database } from '@linode/api-v4';
 import type { Flags } from 'src/featureFlags';
 
 // Feature flag setup
-const flags: Partial<Flags> = {
-  aclp: { beta: true, enabled: true },
-  aclpAlertingTimeOptions: {
-    evaluationPeriodOptions: [{ label: '5 min', value: 300 }],
-    pollingIntervalOptions: [{ label: '5 min', value: 300 }],
-  },
-};
+const flags: Partial<Flags> = { aclp: { beta: true, enabled: true } };
 const mockAccount = accountFactory.build();
 
 // Mock alert details

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -104,20 +104,10 @@ interface LimitsEvolution {
   requestForIncreaseDisabledForInternalAccountsOnly: boolean;
 }
 
-interface AlertTimeDuration {
-  label: string;
-  value: number;
-}
-interface AclpAlertingTimeOptions {
-  evaluationPeriodOptions: AlertTimeDuration[];
-  pollingIntervalOptions: AlertTimeDuration[];
-}
-
 export interface Flags {
   acceleratedPlans: AcceleratedPlansFlag;
   aclp: AclpFlag;
   aclpAlerting: AclpAlerting;
-  aclpAlertingTimeOptions: AclpAlertingTimeOptions;
   aclpAlertServiceTypeConfig: AclpAlertServiceTypeConfig[];
   aclpIntegration: boolean;
   aclpReadEndpoint: string;

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.test.tsx
@@ -4,6 +4,10 @@ import * as React from 'react';
 
 import { renderWithThemeAndHookFormContext } from 'src/utilities/testHelpers';
 
+import {
+  evaluationPeriodOptions,
+  pollingIntervalOptions,
+} from '../../constants';
 import { TriggerConditions } from './TriggerConditions';
 
 import type { CreateAlertDefinitionForm } from '../types';
@@ -11,39 +15,7 @@ import type { CreateAlertDefinitionForm } from '../types';
 const EvaluationPeriodTestId = 'evaluation-period';
 
 const PollingIntervalTestId = 'polling-interval';
-const evaluationPeriodOptions = [
-  { label: '5 min', value: 300 },
-  { label: '15 min', value: 900 },
-  { label: '30 min', value: 1800 },
-  { label: '1 hr', value: 3600 },
-];
-const pollingIntervalOptions = [
-  { label: '5 min', value: 300 },
-  { label: '15 min', value: 900 },
-  { label: '30 min', value: 1800 },
-  { label: '1 hr', value: 3600 },
-];
 
-const queryMocks = vi.hoisted(() => ({
-  useFlags: vi.fn().mockReturnValue({}),
-}));
-
-vi.mock('src/hooks/useFlags', () => {
-  const actual = vi.importActual('src/hooks/useFlags');
-  return {
-    ...actual,
-    useFlags: queryMocks.useFlags,
-  };
-});
-
-beforeEach(() => {
-  queryMocks.useFlags.mockReturnValue({
-    aclpAlertingTimeOptions: {
-      evaluationPeriodOptions,
-      pollingIntervalOptions,
-    },
-  });
-});
 describe('Trigger Conditions', () => {
   const user = userEvent.setup();
 
@@ -73,15 +45,17 @@ describe('Trigger Conditions', () => {
       },
     });
 
-    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
-    const evaluationPeriodToolTip = within(evaluationPeriodscreen).getByRole(
+    const evaluationPeriodContainer = screen.getByTestId(
+      EvaluationPeriodTestId
+    );
+    const evaluationPeriodToolTip = within(evaluationPeriodContainer).getByRole(
       'button',
       {
         name: 'Defines the timeframe for collecting data in polling intervals to understand the service performance. Choose the data lookback period where the thresholds are applied to gather the information impactful for your business.',
       }
     );
-    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
-    const pollingIntervalToolTip = within(pollingIntervalscreen).getByRole(
+    const pollingIntervalContainer = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalToolTip = within(pollingIntervalContainer).getByRole(
       'button',
       {
         name: 'Choose how often you intend to evaluate the alert condition.',
@@ -102,8 +76,10 @@ describe('Trigger Conditions', () => {
         },
       },
     });
-    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
-    const evaluationPeriodInput = within(evaluationPeriodscreen).getByRole(
+    const evaluationPeriodContainer = screen.getByTestId(
+      EvaluationPeriodTestId
+    );
+    const evaluationPeriodInput = within(evaluationPeriodContainer).getByRole(
       'button',
       { name: 'Open' }
     );
@@ -112,24 +88,24 @@ describe('Trigger Conditions', () => {
 
     expect(
       await screen.findByRole('option', {
-        name: evaluationPeriodOptions[1].label,
+        name: evaluationPeriodOptions.linode[1].label,
       })
     ).toBeVisible();
     expect(
       await screen.findByRole('option', {
-        name: evaluationPeriodOptions[2].label,
+        name: evaluationPeriodOptions.linode[2].label,
       })
     ).toBeVisible();
 
     await user.click(
       screen.getByRole('option', {
-        name: evaluationPeriodOptions[0].label,
+        name: evaluationPeriodOptions.linode[0].label,
       })
     );
 
     expect(
-      within(evaluationPeriodscreen).getByRole('combobox')
-    ).toHaveAttribute('value', evaluationPeriodOptions[0].label);
+      within(evaluationPeriodContainer).getByRole('combobox')
+    ).toHaveAttribute('value', evaluationPeriodOptions.linode[0].label);
   });
 
   it('should render the Polling Interval component with options happy path and select an option', async () => {
@@ -143,8 +119,8 @@ describe('Trigger Conditions', () => {
         },
       },
     });
-    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
-    const pollingIntervalInput = within(pollingIntervalscreen).getByRole(
+    const pollingIntervalContainer = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalInput = within(pollingIntervalContainer).getByRole(
       'button',
       { name: 'Open' }
     );
@@ -153,32 +129,31 @@ describe('Trigger Conditions', () => {
 
     expect(
       await screen.findByRole('option', {
-        name: pollingIntervalOptions[1].label,
+        name: pollingIntervalOptions.linode[1].label,
       })
     ).toBeVisible();
 
     expect(
       await screen.findByRole('option', {
-        name: pollingIntervalOptions[2].label,
+        name: pollingIntervalOptions.linode[2].label,
       })
     ).toBeVisible();
 
     await user.click(
       screen.getByRole('option', {
-        name: pollingIntervalOptions[0].label,
+        name: pollingIntervalOptions.linode[0].label,
       })
     );
-    expect(within(pollingIntervalscreen).getByRole('combobox')).toHaveAttribute(
-      'value',
-      pollingIntervalOptions[0].label
-    );
+    expect(
+      within(pollingIntervalContainer).getByRole('combobox')
+    ).toHaveAttribute('value', pollingIntervalOptions.linode[0].label);
   });
 
-  it('should be able to show the options that are greater than or equal to max scraping Interval', async () => {
+  it('should be able to show the options that are greater than or equal to max scraping Interval', () => {
     renderWithThemeAndHookFormContext({
       component: (
         <TriggerConditions
-          maxScrapingInterval={400}
+          maxScrapingInterval={120}
           name="trigger_conditions"
         />
       ),
@@ -188,26 +163,28 @@ describe('Trigger Conditions', () => {
         },
       },
     });
-    const evaluationPeriodscreen = screen.getByTestId(EvaluationPeriodTestId);
-    const evaluationPeriodInput = within(evaluationPeriodscreen).getByRole(
+    const evaluationPeriodContainer = screen.getByTestId(
+      EvaluationPeriodTestId
+    );
+    const evaluationPeriodInput = within(evaluationPeriodContainer).getByRole(
       'button',
       { name: 'Open' }
     );
 
-    await user.click(evaluationPeriodInput);
+    user.click(evaluationPeriodInput);
 
     expect(
-      screen.queryByText(evaluationPeriodOptions[0].label)
+      screen.queryByText(evaluationPeriodOptions.linode[0].label)
     ).not.toBeInTheDocument();
 
-    const pollingIntervalscreen = screen.getByTestId(PollingIntervalTestId);
-    const pollingIntervalInput = within(pollingIntervalscreen).getByRole(
+    const pollingIntervalContainer = screen.getByTestId(PollingIntervalTestId);
+    const pollingIntervalInput = within(pollingIntervalContainer).getByRole(
       'button',
       { name: 'Open' }
     );
-    await user.click(pollingIntervalInput);
+    user.click(pollingIntervalInput);
     expect(
-      screen.queryByText(pollingIntervalOptions[0].label)
+      screen.queryByText(pollingIntervalOptions.linode[0].label)
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/CreateAlert/Criteria/TriggerConditions.tsx
@@ -4,8 +4,10 @@ import * as React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import type { FieldPathByValue } from 'react-hook-form';
 
-import { useFlags } from 'src/hooks/useFlags';
-
+import {
+  evaluationPeriodOptions,
+  pollingIntervalOptions,
+} from '../../constants';
 import { getAlertBoxStyles } from '../../Utils/utils';
 
 import type { CreateAlertDefinitionForm } from '../types';
@@ -32,16 +34,17 @@ export const TriggerConditions = (props: TriggerConditionProps) => {
     control,
     name: 'serviceType',
   });
-  const { aclpAlertingTimeOptions } = useFlags();
   const getPollingIntervalOptions = () => {
-    if (!serviceTypeWatcher || !aclpAlertingTimeOptions) return [];
-    const options = aclpAlertingTimeOptions.pollingIntervalOptions;
+    const options = serviceTypeWatcher
+      ? pollingIntervalOptions[serviceTypeWatcher]
+      : [];
     return options.filter((item) => item.value >= maxScrapingInterval);
   };
 
   const getEvaluationPeriodOptions = () => {
-    if (!serviceTypeWatcher || !aclpAlertingTimeOptions) return [];
-    const options = aclpAlertingTimeOptions.pollingIntervalOptions;
+    const options = serviceTypeWatcher
+      ? evaluationPeriodOptions[serviceTypeWatcher]
+      : [];
     return options.filter((item) => item.value >= maxScrapingInterval);
   };
 


### PR DESCRIPTION
## Description 📝
Reverting back the changes from these previous PRs
-  https://github.com/ACLPManager/manager/pull/310
- https://github.com/ACLPManager/manager/pull/304

## Changes  🔄

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot or screen recording of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: Use `<video src="" />` tag when including recordings in table.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
