### PR TITLE
fix: [DI-26097] - using fetchQuery instead of setQueryData to cover edge case

### DIFF
--- a/packages/manager/src/queries/cloudpulse/alerts.ts
+++ b/packages/manager/src/queries/cloudpulse/alerts.ts
@@ -32,15 +32,12 @@ export const useCreateAlertDefinition = (serviceType: AlertServiceType) => {
   const queryClient = useQueryClient();
   return useMutation<Alert, APIError[], CreateAlertDefinitionPayload>({
     mutationFn: (data) => createAlertDefinition(data, serviceType),
-    onSuccess(newAlert) {
-      queryClient.cancelQueries({
+    onSuccess: async (newAlert) => {
+      await queryClient.cancelQueries({
         queryKey: queryFactory.alerts._ctx.all().queryKey,
       });
 
-      queryClient.setQueryData<Alert[]>(
-        queryFactory.alerts._ctx.all().queryKey,
-        (oldData) => (oldData ? [...oldData, newAlert] : [newAlert])
-      );
+      await queryClient.fetchQuery(queryFactory.alerts._ctx.all());
 
       queryClient.setQueryData(
         queryFactory.alerts._ctx.alertByServiceTypeAndId(


### PR DESCRIPTION
## Description 📝
Using fetchQuery instead of setQueryData to cover edge case

## Changes  🔄
- removed the setQueryData to set the new alert
- using fetchQuery to fetch alerts if the cache is expired or empty. 

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷


https://github.com/user-attachments/assets/adfef61a-0b66-4373-9a10-579d5105a7b7


## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [x] All unit tests are passing
- [x] TypeScript compilation succeeded without errors
- [x] Code passes all linting rules

</details>
