### PR TITLE
Fix:[DI-26189] - Fix filter retention issue

### DIFF
--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -115,6 +115,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
     };
 
     const availableOptions = getNodeTypeOptions(isClusterSizeGreaterThanOne);
+    const databaseIdsKey = database_ids?.sort().join(','); // sort and join database ids to create a unique key for the effect
 
     React.useEffect(() => {
       // when savePreferences is false, we retain the primary selection as default selected value
@@ -144,11 +145,7 @@ export const CloudPulseNodeTypeFilter = React.memo(
         handleNodeTypeChange(undefined, []);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-      savePreferences,
-      isClusterSizeGreaterThanOne,
-      database_ids?.sort().join(','),
-    ]);
+    }, [savePreferences, isClusterSizeGreaterThanOne, databaseIdsKey]);
 
     return (
       <Autocomplete

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseNodeTypeFilter.tsx
@@ -144,7 +144,11 @@ export const CloudPulseNodeTypeFilter = React.memo(
         handleNodeTypeChange(undefined, []);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [savePreferences, database_ids?.sort().join(',')]);
+    }, [
+      savePreferences,
+      isClusterSizeGreaterThanOne,
+      database_ids?.sort().join(','),
+    ]);
 
     return (
       <Autocomplete


### PR DESCRIPTION
## Description 📝

Fix node type filter retention issue.

## Changes  🔄

- Sometimes on window focus, the database clusters didn't load quickly due to refetch and so node type options couldn't be determined leading to no default selection from preferences, though the selected database_ids got loaded from preferences. This is now fixed by use of appropriate dependency in useffect.

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷
Before:

https://github.com/user-attachments/assets/5222c77f-d8ad-42c4-90e1-88938334a4f4


After:

 https://github.com/user-attachments/assets/73cc13a5-6d33-4da9-91f8-9de6fe4293f4 

## How to test 🧪

### Verification steps

- Navigate to `/metrics` page.
- Select databases dashboard and all the mandatory filters.
- Open new tab and see if all the filters are retained.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
