### PR TITLE
[DI-26394] - reuse type

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -73,7 +73,7 @@ interface AclpFlag {
    */
   beta: boolean;
   /**
-   * This property indicates whether to bypass account capabilities
+   * This property indicates whether to bypass account capabilities check or not
    */
   bypassAccountCapabilities?: boolean;
   /**

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -68,8 +68,17 @@ interface GeckoFeatureFlag extends BaseFeatureFlag {
 }
 
 interface AclpFlag {
+  /**
+   * This property indicates whether the feature is in beta
+   */
   beta: boolean;
+  /**
+   * This property indicates whether to bypass account capabilities
+   */
   bypassAccountCapabilities?: boolean;
+  /**
+   * This property indicates whether the feature is enabled
+   */
   enabled: boolean;
 }
 
@@ -315,16 +324,9 @@ export interface AclpAlertServiceTypeConfig {
   // This can be extended to have supportedRegions, supportedFilters and other tags
 }
 
-interface AclpServiceStatus {
-  // Whether the service is in beta
-  beta: boolean;
-  // Whether the service is enabled
-  enabled: boolean;
-}
-
 export type AclpServices = {
   [serviceType in CloudPulseServiceType]: {
-    alerts: AclpServiceStatus;
-    metrics: AclpServiceStatus;
+    alerts: AclpFlag;
+    metrics: AclpFlag;
   };
 };


### PR DESCRIPTION
## Description 📝
Reuse existing type.

## Changes  🔄

- Reused existing `AclpFlag` type in `AclpServices` interface instead of `AclpServiceStatus` type.

## Target release date 🗓️
--

## Preview 📷

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

### Verification steps
- Confirm ACLP services functionality remains unchanged.

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

---
