### PR TITLE
test[DI-28587]: Add permission tests for Notification Channel Management

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -43,7 +43,6 @@ describe('Notification Channel Listing Page — Access Control', () => {
     cy.url().should('endWith', 'alerts/notification-channels');
   });
 
- 
   it('hides the Notification Channels tab when notificationChannels is disabled', () => {
     const flags: Partial<Flags> = {
       aclp: { beta: true, enabled: true },

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -66,7 +66,6 @@ describe('Notification Channel Listing Page — Access Control', () => {
     ui.tabList.findTabByTitle('Notification Channels').should('not.exist');
   });
 
-
   it('blocks all access when CloudPulse is disabled', () => {
     const flags: Partial<Flags> = {
       aclp: { beta: true, enabled: false }, // CloudPulse OFF

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
  *
- * Covers three access-control behaviors:
+ * Covers four access-control behaviors:
  * 1. Access is allowed when `notificationChannels` is true.
  * 2. Navigation/tab visibility is blocked when `notificationChannels` is false.
  * 3. Direct URL access is blocked when `notificationChannels` is false.

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
+ *
+ * Covers three access-control behaviors:
+ * 1. Access is allowed when `notificationChannels` is true.
+ * 2. Navigation/tab visibility is blocked when `notificationChannels` is false.
+ * 3. Direct URL access is blocked when `notificationChannels` is false.
+ * 4. All access is blocked when CloudPulse (`aclp`) is disabled.
+ */
+
+import { mockGetAccount } from 'support/intercepts/account';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { ui } from 'support/ui';
+
+import { accountFactory } from 'src/factories';
+
+import type { Flags } from 'src/featureFlags';
+
+describe('Notification Channel Listing Page — Access Control', () => {
+  beforeEach(() => {
+    mockGetAccount(accountFactory.build());
+  });
+
+ 
+  it('allows access when notificationChannels is enabled', () => {
+    const flags: Partial<Flags> = {
+      aclp: { beta: true, enabled: true },
+      aclpAlerting: {
+        accountAlertLimit: 10,
+        accountMetricLimit: 10,
+        alertDefinitions: true,
+        beta: true,
+        recentActivity: false,
+        notificationChannels: true,
+      },
+    };
+
+    mockAppendFeatureFlags(flags);
+    cy.visitWithLogin('/linodes');
+
+    ui.nav.findItemByTitle('Alerts').should('be.visible').click();
+    ui.tabList.findTabByTitle('Notification Channels').should('be.visible').click();
+
+    cy.url().should('endWith', 'alerts/notification-channels');
+  });
+
+ 
+  it('hides the Notification Channels tab when notificationChannels is disabled', () => {
+    const flags: Partial<Flags> = {
+      aclp: { beta: true, enabled: true },
+      aclpAlerting: {
+        accountAlertLimit: 10,
+        accountMetricLimit: 10,
+        alertDefinitions: true,
+        beta: true,
+        recentActivity: false,
+        notificationChannels: false,
+      },
+    };
+
+    mockAppendFeatureFlags(flags);
+    cy.visitWithLogin('/linodes');
+
+    ui.nav.findItemByTitle('Alerts').should('be.visible').click();
+
+    // Tab should not render at all
+    ui.tabList.findTabByTitle('Notification Channels').should('not.exist');
+  });
+
+
+  it('blocks all access when CloudPulse is disabled', () => {
+    const flags: Partial<Flags> = {
+      aclp: { beta: true, enabled: false }, // CloudPulse OFF
+      aclpAlerting: {
+        accountAlertLimit: 10,
+        accountMetricLimit: 10,
+        alertDefinitions: true,
+        beta: true,
+        recentActivity: false,
+        notificationChannels: true,
+      },
+    };
+
+    mockAppendFeatureFlags(flags);
+    cy.visitWithLogin('/alerts/notification-channels');
+
+    // Application should return fallback
+    cy.findByText('Not Found').should('be.visible');
+  });
+
+  it('blocks direct URL access to /alerts/notification-channels when notificationChannels is disabled', () => {
+    const flags: Partial<Flags> = {
+      aclp: { beta: true, enabled: true },
+
+      aclpAlerting: {
+        accountAlertLimit: 10,
+        accountMetricLimit: 10,
+        alertDefinitions: true,
+        beta: true,
+        recentActivity: false,
+        notificationChannels: false, // feature OFF → user should not enter page
+      },
+    };
+
+    mockAppendFeatureFlags(flags);
+    cy.visitWithLogin('/alerts/notification-channels');
+    // Tab must not exist
+    ui.tabList.findTabByTitle('Notification Channels').should('not.exist');
+  });
+});

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -89,7 +89,6 @@ describe('Notification Channel Listing Page — Access Control', () => {
   it('blocks direct URL access to /alerts/notification-channels when notificationChannels is disabled', () => {
     const flags: Partial<Flags> = {
       aclp: { beta: true, enabled: true },
-
       aclpAlerting: {
         accountAlertLimit: 10,
         accountMetricLimit: 10,

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -21,7 +21,6 @@ describe('Notification Channel Listing Page — Access Control', () => {
     mockGetAccount(accountFactory.build());
   });
 
- 
   it('allows access when notificationChannels is enabled', () => {
     const flags: Partial<Flags> = {
       aclp: { beta: true, enabled: true },


### PR DESCRIPTION
## Description 📝

This PR adds comprehensive permission tests for the CloudPulse Notification Channel Management feature, verifying access control behavior across different feature flag configurations.

Adds integration tests covering four access-control scenarios for the Notification Channels listing page
Tests validate proper behavior when features are enabled, disabled, or partially accessible
Ensures both UI navigation and direct URL access are properly restricted based on permissions

## Changes  🔄

List any change(s) relevant to the reviewer.

- ...
- ...

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->