### PR TITLE
Alerts notification channel feature santosh december 05

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-errors.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-errors.spec.ts
@@ -1,5 +1,6 @@
 import { mockGetAccount } from 'support/intercepts/account';
 import {
+  mockGetAlertChannelsTypeError,
   mockGetAllAlertDefinitions,
   mockGetCloudPulseServices,
   mockUpdateAlertDefinitionsError,
@@ -93,5 +94,18 @@ describe('Alerts Listing Page - Error Handling', () => {
     // Enable "Alert-2"
     searchAlert('Alert-2');
     toggleAlertStatus('Alert-2', 'Enable', '@getSecondAlertDefinitions');
+  });
+
+  it('shows the correct error message when loading notification channels fails', () => {
+    const errorMessage = 'Error in fetching the notification channels.';
+    mockGetAlertChannelsTypeError(errorMessage).as('getAlertChannelsError');
+
+    cy.visitWithLogin('/alerts/notification-channels');
+
+    cy.wait('@getAlertChannelsError');
+
+    cy.get('[data-qa-error-msg="true"]')
+      .should('be.visible')
+      .and('have.text', errorMessage);
   });
 });

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -1,7 +1,6 @@
 /**
  * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
  */
-
 import { profileFactory } from '@linode/utilities';
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockGetAlertChannels } from 'support/intercepts/cloudpulse';
@@ -18,7 +17,9 @@ import { formatDate } from 'src/utilities/formatDate';
 
 import type { NotificationChannel } from '@linode/api-v4';
 
-const notificationChannels = notificationChannelFactory.buildList(26).map((ch, i) => {
+let notificationChannels = notificationChannelFactory.buildList(26);
+
+notificationChannels = notificationChannels.map((ch, i) => {
   const alertCount = i % 2 === 0 ? 5 : 3;
   const channelType = i % 2 === 0 ? 'user' : 'system';
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -123,10 +123,6 @@ const verifyChannelSorting = (
         .map((row) =>
           Number(row.getAttribute('data-qa-notification-channel-cell'))
         );
-
-      cy.log(`Actual order: ${actualOrder.join(', ')}`);
-      cy.log(`Expected order: ${expected.join(', ')}`);
-
       expect(actualOrder).to.deep.equal(expected);
     }
   );

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -1,6 +1,7 @@
 /**
  * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
  */
+
 import { profileFactory } from '@linode/utilities';
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockGetAlertChannels } from 'support/intercepts/cloudpulse';
@@ -51,6 +52,13 @@ const isEmailContent = (
 const mockProfile = profileFactory.build({
   timezone: 'gmt',
 });
+
+/**
+ * Verifies sorting of a column in the alerts table.
+ * @param {string} header - The `data-qa-header` attribute of the column to sort.
+ * @param {'ascending' | 'descending'} sortOrder - Expected sorting order.
+ * @param {number[]} expectedValues - Expected values in sorted order.
+ */
 const verifyChannelSorting = (
   columnLabel: string,
   sortOrder: 'ascending' | 'descending',
@@ -92,6 +100,7 @@ const verifyChannelSorting = (
     }
   );
 };
+
 describe('Notification Channel Listing Page', () => {
   beforeEach(() => {
     mockAppendFeatureFlags(flagsFactory.build());
@@ -101,7 +110,6 @@ describe('Notification Channel Listing Page', () => {
       'getAlertNotificationChannels'
     );
     cy.visitWithLogin('/alerts/notification-channels');
-    cy.wait('@getAlertNotificationChannels');
   });
 
   it('displays notification channel data correctly', () => {

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -14,9 +14,15 @@ import {
   flagsFactory,
   notificationChannelFactory,
 } from 'src/factories';
+import { ChannelAlertsTooltipText,ChannelListingTableLabelMap } from 'src/features/CloudPulse/Alerts/NotificationChannels/NotificationsChannelsListing/constants';
 import { formatDate } from 'src/utilities/formatDate';
 
 import type { NotificationChannel } from '@linode/api-v4';
+
+const sortOrderMap = {
+  ascending: 'asc',
+  descending: 'desc',
+};
 
 let notificationChannels = notificationChannelFactory.buildList(26);
 
@@ -126,6 +132,17 @@ const verifyChannelSorting = (
       expect(actualOrder).to.deep.equal(expected);
     }
   );
+  const order = sortOrderMap[sortOrder];
+  const orderBy =
+  Object.fromEntries(
+    ChannelListingTableLabelMap.map(mapping => [mapping.colName, mapping.label])
+  )[columnLabel];
+
+
+  cy.url().should(
+    'endWith',
+    `/alerts/notification-channels?order=${order}&orderBy=${orderBy}`
+  );
 };
 
 describe('Notification Channel Listing Page', () => {
@@ -141,14 +158,17 @@ describe('Notification Channel Listing Page', () => {
     mockGetAlertChannels(notificationChannels).as(
       'getAlertNotificationChannels'
     );
+
     cy.visitWithLogin('/alerts/notification-channels');
+
     ui.pagination.findPageSizeSelect().click();
+
     cy.get('[data-qa-pagination-page-size-option="100"]')
       .should('exist')
       .click();
-  });
 
-  it('displays notification channel data correctly', () => {
+    ui.tooltip.findByText(ChannelAlertsTooltipText).should('be.visible');
+
     cy.wait('@getAlertNotificationChannels').then(({ response }) => {
       const body = response?.body;
       const data = body?.data;
@@ -198,6 +218,7 @@ describe('Notification Channel Listing Page', () => {
       });
     });
   });
+
   it('searches and validates notification channel details', () => {
     cy.findByPlaceholderText('Search for Notification Channels').as(
       'searchInput'

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
+ */
+
+import { profileFactory } from '@linode/utilities';
+import { mockGetAccount } from 'support/intercepts/account';
+import { mockGetAlertChannels } from 'support/intercepts/cloudpulse';
+import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
+import { mockGetProfile } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+
+import {
+  accountFactory,
+  flagsFactory,
+  notificationChannelFactory,
+} from 'src/factories';
+import { formatDate } from 'src/utilities/formatDate';
+
+import type { NotificationChannel } from '@linode/api-v4';
+
+let notificationChannels = notificationChannelFactory.buildList(26);
+
+notificationChannels = notificationChannels.map((ch, i) => {
+  const alertCount = i % 2 === 0 ? 5 : 3;
+  const channelType = i % 2 === 0 ? 'user' : 'system';
+
+  return {
+    ...ch,
+    type: channelType,
+    created_by: channelType,
+    updated_by: channelType,
+    updated: new Date().toISOString(),
+
+    alerts: Array.from({ length: alertCount }).map((_, idx) => ({
+      id: idx + 1,
+      label: `Alert-${idx + 1}`,
+      type: 'alerts-definitions',
+      url: 'Sample',
+    })),
+  };
+});
+
+const isEmailContent = (
+  content: NotificationChannel['content']
+): content is {
+  email: {
+    email_addresses: string[];
+    message: string;
+    subject: string;
+  };
+} => 'email' in content;
+const mockProfile = profileFactory.build({
+  timezone: 'gmt',
+});
+
+describe('Notification Channel Listing Page', () => {
+  beforeEach(() => {
+    mockAppendFeatureFlags(flagsFactory.build());
+    mockGetProfile(mockProfile);
+    mockGetAccount(accountFactory.build());
+    mockGetAlertChannels(notificationChannels).as(
+      'getAlertNotificationChannels'
+    );
+    cy.visitWithLogin('/alerts/notification-channels');
+  });
+
+  it('displays notification channel data correctly', () => {
+    cy.wait('@getAlertNotificationChannels').then(({ response }) => {
+      const body = response?.body;
+      const data = body?.data;
+
+      const channels = data as NotificationChannel[];
+
+      expect(body?.results).to.eq(notificationChannels.length);
+
+      channels.forEach((item, index) => {
+        const expected = notificationChannels[index];
+
+        // Basic fields
+        expect(item.id).to.eq(expected.id);
+        expect(item.label).to.eq(expected.label);
+        expect(item.type).to.eq(expected.type);
+        expect(item.status).to.eq(expected.status);
+        expect(item.channel_type).to.eq(expected.channel_type);
+
+        // Creator/updater fields
+        expect(item.created_by).to.eq(expected.created_by);
+        expect(item.updated_by).to.eq(expected.updated_by);
+
+        // Email content (safe narrow)
+        if (isEmailContent(item.content) && isEmailContent(expected.content)) {
+          expect(item.content.email.email_addresses).to.deep.eq(
+            expected.content.email.email_addresses
+          );
+          expect(item.content.email.subject).to.eq(
+            expected.content.email.subject
+          );
+          expect(item.content.email.message).to.eq(
+            expected.content.email.message
+          );
+        }
+
+        // Alerts list
+        expect(item.alerts.length).to.eq(expected.alerts.length);
+
+        item.alerts.forEach((alert, aIndex) => {
+          const expAlert = expected.alerts[aIndex];
+
+          expect(alert.id).to.eq(expAlert.id);
+          expect(alert.label).to.eq(expAlert.label);
+          expect(alert.type).to.eq(expAlert.type);
+          expect(alert.url).to.eq(expAlert.url);
+        });
+      });
+    });
+  });
+  it('searches and validates notification channel details', () => {
+    cy.findByPlaceholderText('Search for Notification Channels').as(
+      'searchInput'
+    );
+    // Change pagination size selection from "Show 25" to "Show 100".
+    ui.pagination.findPageSizeSelect().click();
+    cy.get('[data-qa-pagination-page-size-option="100"]')
+      .should('exist')
+      .click();
+
+    // Before clearing the search input, verify the table shows all rows
+    cy.get('[data-qa="notification-channels-table"]')
+      .find('tbody')
+      .last()
+      .within(() => {
+        cy.get('tr').should('have.length', 26);
+      });
+
+    cy.get('@searchInput').clear();
+    cy.get('@searchInput').type('Channel-10');
+    cy.get('[data-qa="notification-channels-table"]')
+      .find('tbody')
+      .last()
+      .within(() => {
+        cy.get('tr').should('have.length', 1);
+
+        cy.get('tr').each(($row) => {
+          const expected = notificationChannels[9];
+
+          cy.wrap($row).within(() => {
+            cy.findByText(expected.label).should('be.visible');
+            cy.findByText(String(expected.alerts.length)).should('be.visible');
+            cy.findByText('Email').should('be.visible');
+            cy.get('td').eq(3).should('have.text', expected.created_by);
+            cy.findByText(
+              formatDate(expected.updated, {
+                format: 'MMM dd, yyyy, h:mm a',
+                timezone: 'GMT',
+              })
+            ).should('be.visible');
+            cy.get('td').eq(5).should('have.text', expected.updated_by);
+          });
+        });
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -30,60 +30,61 @@ const LabelLookup = Object.fromEntries(
   ChannelListingTableLabelMap.map((item) => [item.colName, item.label])
 );
 
-let notificationChannels = notificationChannelFactory.buildList(26);
-notificationChannels = notificationChannels.map((ch, i) => {
-  const isEmail = i % 2 === 0;
-  const alerts = Array.from({ length: isEmail ? 5 : 3 }).map((_, idx) => ({
-    id: idx + 1,
-    label: `Alert-${idx + 1}`,
-    type: 'alerts-definitions',
-    url: 'Sample',
-  }));
+const notificationChannels = notificationChannelFactory
+  .buildList(26)
+  .map((ch, i) => {
+    const isEmail = i % 2 === 0;
+    const alerts = Array.from({ length: isEmail ? 5 : 3 }).map((_, idx) => ({
+      id: idx + 1,
+      label: `Alert-${idx + 1}`,
+      type: 'alerts-definitions',
+      url: 'Sample',
+    }));
 
-  if (isEmail) {
-    return {
-      ...ch,
-      id: i + 1,
-      label: `Channel-${i + 1}`,
-      type: 'user',
-      created_by: 'user',
-      updated_by: 'user',
-      channel_type: 'email',
-      updated: new Date(2024, 0, i + 1).toISOString(),
-      alerts,
-      content: {
-        email: {
-          email_addresses: [`test-${i + 1}@example.com`],
-          subject: 'Test Subject',
-          message: 'Test message',
+    if (isEmail) {
+      return {
+        ...ch,
+        id: i + 1,
+        label: `Channel-${i + 1}`,
+        type: 'user',
+        created_by: 'user',
+        updated_by: 'user',
+        channel_type: 'email',
+        updated: new Date(2024, 0, i + 1).toISOString(),
+        alerts,
+        content: {
+          email: {
+            email_addresses: [`test-${i + 1}@example.com`],
+            subject: 'Test Subject',
+            message: 'Test message',
+          },
         },
-      },
-    } as NotificationChannel;
-  } else {
-    return {
-      ...ch,
-      id: i + 1,
-      label: `Channel-${i + 1}`,
-      type: 'system',
-      created_by: 'system',
-      updated_by: 'system',
-      channel_type: 'webhook',
-      updated: new Date(2024, 0, i + 1).toISOString(),
-      alerts,
-      content: {
-        webhook: {
-          webhook_url: `https://example.com/webhook/${i + 1}`,
-          http_headers: [
-            {
-              header_key: 'Authorization',
-              header_value: 'Bearer secret-token',
-            },
-          ],
+      } as NotificationChannel;
+    } else {
+      return {
+        ...ch,
+        id: i + 1,
+        label: `Channel-${i + 1}`,
+        type: 'system',
+        created_by: 'system',
+        updated_by: 'system',
+        channel_type: 'webhook',
+        updated: new Date(2024, 0, i + 1).toISOString(),
+        alerts,
+        content: {
+          webhook: {
+            webhook_url: `https://example.com/webhook/${i + 1}`,
+            http_headers: [
+              {
+                header_key: 'Authorization',
+                header_value: 'Bearer secret-token',
+              },
+            ],
+          },
         },
-      },
-    } as NotificationChannel;
-  }
-});
+      } as NotificationChannel;
+    }
+  });
 
 const isEmailContent = (
   content: NotificationChannel['content']

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -25,15 +25,14 @@ const sortOrderMap = {
   ascending: 'asc',
   descending: 'desc',
 };
+
 const LabelLookup = Object.fromEntries(
   ChannelListingTableLabelMap.map((item) => [item.colName, item.label])
 );
 
 let notificationChannels = notificationChannelFactory.buildList(26);
-
 notificationChannels = notificationChannels.map((ch, i) => {
   const isEmail = i % 2 === 0;
-
   const alerts = Array.from({ length: isEmail ? 5 : 3 }).map((_, idx) => ({
     id: idx + 1,
     label: `Alert-${idx + 1}`,

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -1,7 +1,6 @@
 /**
  * @file Integration Tests for CloudPulse Alerting — Notification Channel Listing Page
  */
-
 import { profileFactory } from '@linode/utilities';
 import { mockGetAccount } from 'support/intercepts/account';
 import { mockGetAlertChannels } from 'support/intercepts/cloudpulse';
@@ -26,6 +25,9 @@ const sortOrderMap = {
   ascending: 'asc',
   descending: 'desc',
 };
+const LabelLookup = Object.fromEntries(
+  ChannelListingTableLabelMap.map((item) => [item.colName, item.label])
+);
 
 let notificationChannels = notificationChannelFactory.buildList(26);
 
@@ -136,13 +138,7 @@ const verifyChannelSorting = (
     }
   );
   const order = sortOrderMap[sortOrder];
-  const orderBy = Object.fromEntries(
-    ChannelListingTableLabelMap.map((mapping) => [
-      mapping.colName,
-      mapping.label,
-    ])
-  )[columnLabel];
-
+  const orderBy = LabelLookup[columnLabel];
   cy.url().should(
     'endWith',
     `/alerts/notification-channels?order=${order}&orderBy=${orderBy}`

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -18,9 +18,7 @@ import { formatDate } from 'src/utilities/formatDate';
 
 import type { NotificationChannel } from '@linode/api-v4';
 
-let notificationChannels = notificationChannelFactory.buildList(26);
-
-notificationChannels = notificationChannels.map((ch, i) => {
+const notificationChannels = notificationChannelFactory.buildList(26).map((ch, i) => {
   const alertCount = i % 2 === 0 ? 5 : 3;
   const channelType = i % 2 === 0 ? 'user' : 'system';
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -52,7 +52,47 @@ const isEmailContent = (
 const mockProfile = profileFactory.build({
   timezone: 'gmt',
 });
+const verifyChannelSorting = (
+  columnLabel: string,
+  sortOrder: 'ascending' | 'descending',
+  expected: number[]
+) => {
+  // Initial click
+  cy.get(`[data-qa-header="${columnLabel}"]`).click({ force: true });
 
+  // Wait for DOM update, then check and correct
+  cy.get(`[data-qa-header="${columnLabel}"]`)
+    .invoke('attr', 'aria-sort')
+    .then((current) => {
+      if (current !== sortOrder) {
+        // Click again ONLY if needed
+        cy.get(`[data-qa-header="${columnLabel}"]`).click({ force: true });
+      }
+    });
+
+  // Now assert stable final state (Cypress auto-retries this)
+  cy.get(`[data-qa-header="${columnLabel}"]`).should(
+    'have.attr',
+    'aria-sort',
+    sortOrder
+  );
+
+  // Validate row order
+  cy.get('[data-qa="notification-channels-table"] tbody:last-of-type tr').then(
+    ($rows) => {
+      const actualOrder = $rows
+        .toArray()
+        .map((row) =>
+          Number(row.getAttribute('data-qa-notification-channel-cell'))
+        );
+
+      cy.log(`Actual order: ${actualOrder.join(', ')}`);
+      cy.log(`Expected order: ${expected.join(', ')}`);
+
+      expect(actualOrder).to.deep.equal(expected);
+    }
+  );
+};
 describe('Notification Channel Listing Page', () => {
   beforeEach(() => {
     mockAppendFeatureFlags(flagsFactory.build());
@@ -62,6 +102,7 @@ describe('Notification Channel Listing Page', () => {
       'getAlertNotificationChannels'
     );
     cy.visitWithLogin('/alerts/notification-channels');
+    cy.wait('@getAlertNotificationChannels');
   });
 
   it('displays notification channel data correctly', () => {
@@ -158,5 +199,133 @@ describe('Notification Channel Listing Page', () => {
           });
         });
       });
+  });
+
+  it('sorting and validates notification channel details', () => {
+    const fixedDates = [
+      '2024-01-01T10:00:00Z',
+      '2024-01-01T11:15:00Z',
+      '2024-01-01T12:30:00Z',
+      '2024-01-01T13:45:00Z',
+      '2024-01-01T15:00:00Z',
+    ];
+
+    const sortColumns = [
+      {
+        column: 'Channel Name',
+        ascending: [1, 2, 3, 4, 5],
+        descending: [5, 4, 3, 2, 1],
+      },
+      {
+        column: 'Alerts',
+        ascending: [2, 4, 1, 3, 5],
+        descending: [1, 3, 5, 2, 4],
+      },
+      {
+        column: 'Channel Type',
+        ascending: [1, 3, 5, 2, 4],
+        descending: [2, 4, 1, 3, 5],
+      },
+      {
+        column: 'Created By',
+        ascending: [2, 4, 1, 3, 5],
+        descending: [1, 3, 5, 2, 4],
+      },
+      {
+        column: 'Last Modified',
+        ascending: [1, 2, 3, 4, 5],
+        descending: [5, 4, 3, 2, 1],
+      },
+      {
+        column: 'Last Modified By',
+        ascending: [2, 4, 1, 3, 5],
+        descending: [1, 3, 5, 2, 4],
+      },
+    ];
+
+    let notificationChannels = notificationChannelFactory.buildList(5);
+
+    notificationChannels = notificationChannels.map((ch, i) => {
+      const isEmail = i % 2 === 0;
+
+      const alerts = Array.from({ length: isEmail ? 5 : 3 }).map((_, idx) => ({
+        id: idx + 1,
+        label: `Alert-${idx + 1}`,
+        type: 'alerts-definitions',
+        url: 'Sample',
+      }));
+
+      if (isEmail) {
+        return {
+          ...ch,
+          id: i + 1,
+          label: `Channel-${i + 1}`,
+          type: 'user',
+          created_by: 'user',
+          updated_by: 'user',
+          updated: fixedDates[i],
+          channel_type: 'email',
+          alerts,
+          content: {
+            email: {
+              email_addresses: [`test-${i + 1}@example.com`],
+              subject: 'Test Subject',
+              message: 'Test message',
+            },
+          },
+        } as NotificationChannel;
+      } else {
+        return {
+          ...ch,
+          id: i + 1,
+          label: `Channel-${i + 1}`,
+          type: 'system',
+          created_by: 'system',
+          updated_by: 'system',
+          updated: fixedDates[i],
+          channel_type: 'webhook',
+          alerts,
+          content: {
+            webhook: {
+              webhook_url: `https://example.com/webhook/${i + 1}`,
+              http_headers: [
+                {
+                  header_key: 'Authorization',
+                  header_value: 'Bearer secret-token',
+                },
+              ],
+            },
+          },
+        } as NotificationChannel;
+      }
+    });
+
+    mockGetAlertChannels(notificationChannels).as('getNotificationChannels');
+
+    cy.visitWithLogin('/alerts/notification-channels');
+    cy.wait('@getNotificationChannels');
+    cy.get('[data-qa="notification-channels-table"] thead th').as('headers');
+
+    cy.get('@headers').then(($headers) => {
+      const actual = Array.from($headers)
+        .map((th) => th.textContent ?? '')
+        .filter(Boolean);
+
+      expect(actual.length).to.equal(6);
+
+      expect(actual).to.deep.equal([
+        'Channel Name',
+        'Alerts',
+        'Channel Type',
+        'Created By',
+        'Last Modified',
+        'Last Modified By',
+      ]);
+    });
+
+    sortColumns.forEach(({ column, ascending, descending }) => {
+      verifyChannelSorting(column, 'ascending', ascending);
+      verifyChannelSorting(column, 'descending', descending);
+    });
   });
 });

--- a/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alert-notification-channel-list.spec.ts
@@ -14,7 +14,10 @@ import {
   flagsFactory,
   notificationChannelFactory,
 } from 'src/factories';
-import { ChannelAlertsTooltipText,ChannelListingTableLabelMap } from 'src/features/CloudPulse/Alerts/NotificationChannels/NotificationsChannelsListing/constants';
+import {
+  ChannelAlertsTooltipText,
+  ChannelListingTableLabelMap,
+} from 'src/features/CloudPulse/Alerts/NotificationChannels/NotificationsChannelsListing/constants';
 import { formatDate } from 'src/utilities/formatDate';
 
 import type { NotificationChannel } from '@linode/api-v4';
@@ -133,11 +136,12 @@ const verifyChannelSorting = (
     }
   );
   const order = sortOrderMap[sortOrder];
-  const orderBy =
-  Object.fromEntries(
-    ChannelListingTableLabelMap.map(mapping => [mapping.colName, mapping.label])
+  const orderBy = Object.fromEntries(
+    ChannelListingTableLabelMap.map((mapping) => [
+      mapping.colName,
+      mapping.label,
+    ])
   )[columnLabel];
-
 
   cy.url().should(
     'endWith',

--- a/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/alerting-notification-channel-permission-tests.spec.ts
@@ -38,7 +38,10 @@ describe('Notification Channel Listing Page — Access Control', () => {
     cy.visitWithLogin('/linodes');
 
     ui.nav.findItemByTitle('Alerts').should('be.visible').click();
-    ui.tabList.findTabByTitle('Notification Channels').should('be.visible').click();
+    ui.tabList
+      .findTabByTitle('Notification Channels')
+      .should('be.visible')
+      .click();
 
     cy.url().should('endWith', 'alerts/notification-channels');
   });

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -393,6 +393,23 @@ export const mockGetAlertChannels = (
     paginateResponse(channel)
   );
 };
+
+/**
+ * Mocks an error response for the GET request to retrieve alert channels in CloudPulse.
+ *
+ * Intercepts the GET request to CloudPulse alert channels and simulates a 404 error.
+ *
+ * @returns {Cypress.Chainable<null>} - A Cypress chainable object indicating the interception.
+ */
+export const mockGetAlertChannelsTypeError = (
+  errorMessage: string
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('/monitor/alert-channels*'),
+    makeErrorResponse(errorMessage, 400)
+  );
+};
 /**
  * Mocks the API response for creating a new alert definition in the monitoring service.
  * This function intercepts a POST request to create alert definitions and returns a mock

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -632,27 +632,3 @@ export const mockGetCloudPulseServiceByType = (
     makeResponse(service)
   );
 };
-/**
- * Mocks the API response for fetching CloudPulse notification (alert) channels.
- *
- * Intercepts the GET request to `monitor/alert-channels` and returns
- * the provided list of notification channels. This endpoint is not paginated,
- * so the mock must return a simple array of channel objects.
- *
- * @param {NotificationChannel[]} channels
- *   An array of notification channel objects to return in the API response.
- *   Each object must match the NotificationChannel model, including:
- *
- * @returns {Cypress.Chainable}
- *   A Cypress chainable that continues the test flow after registering the intercept.
- */
-
-export const mockGetNotificationChannels = (
-  channels: NotificationChannel[]
-): Cypress.Chainable => {
-  return cy.intercept(
-    'GET',
-    apiMatcher('monitor/alert-channels*'),
-    paginateResponse(channels)
-  );
-};

--- a/packages/manager/cypress/support/intercepts/cloudpulse.ts
+++ b/packages/manager/cypress/support/intercepts/cloudpulse.ts
@@ -615,3 +615,27 @@ export const mockGetCloudPulseServiceByType = (
     makeResponse(service)
   );
 };
+/**
+ * Mocks the API response for fetching CloudPulse notification (alert) channels.
+ *
+ * Intercepts the GET request to `monitor/alert-channels` and returns
+ * the provided list of notification channels. This endpoint is not paginated,
+ * so the mock must return a simple array of channel objects.
+ *
+ * @param {NotificationChannel[]} channels
+ *   An array of notification channel objects to return in the API response.
+ *   Each object must match the NotificationChannel model, including:
+ *
+ * @returns {Cypress.Chainable}
+ *   A Cypress chainable that continues the test flow after registering the intercept.
+ */
+
+export const mockGetNotificationChannels = (
+  channels: NotificationChannel[]
+): Cypress.Chainable => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('monitor/alert-channels*'),
+    paginateResponse(channels)
+  );
+};

--- a/packages/manager/src/factories/featureFlags.ts
+++ b/packages/manager/src/factories/featureFlags.ts
@@ -26,7 +26,7 @@ export const flagsFactory = Factory.Sync.makeFactory<Partial<Flags>>({
     alertDefinitions: true,
     beta: true,
     recentActivity: false,
-    notificationChannels: false,
+    notificationChannels: true,
     editDisabledStatuses: [
       'in progress',
       'failed',

--- a/packages/manager/src/features/CloudPulse/Alerts/NotificationChannels/NotificationsChannelsListing/NotificationChannelListTable.tsx
+++ b/packages/manager/src/features/CloudPulse/Alerts/NotificationChannels/NotificationsChannelsListing/NotificationChannelListTable.tsx
@@ -129,6 +129,8 @@ export const NotificationChannelListTable = React.memo(
                       {ChannelListingTableLabelMap.map((value) => (
                         <TableSortCell
                           active={orderBy === value.label}
+                          data-qa-header={value.colName}
+                          data-qa-sorting={value.colName}
                           direction={order}
                           handleClick={handleTableSort}
                           key={value.label}


### PR DESCRIPTION
## Description 📝

This PR implements the notification channels listing feature for CloudPulse alerts, enabling users to view and search through their configured notification channels with detailed information about each channel.

Key Changes:

Added a complete notification channels listing page with table view, search functionality, and pagination
Implemented data fetching, filtering, and display logic for notification channels
Added comprehensive test coverage for the new components and features

## Changes  🔄

List any change(s) relevant to the reviewer.

- ...
- ...

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->