### PR TITLE
upcoming: [DI-28563] - Time range picker fix and optimisations

### DIFF
--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../GroupBy/utils', async () => {
   };
 });
 const mockDashboard = dashboardFactory.build();
+const PRESET_BUTTON_ID = 'preset-button';
 
 describe('CloudPulseDashboardWithFilters component tests', () => {
   it('renders a CloudPulseDashboardWithFilters component with error placeholder', () => {
@@ -90,9 +91,9 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
     const groupByIcon = screen.getByTestId('group-by');
     expect(groupByIcon).toBeEnabled();
 
-    const startDate = screen.getByText('Start Date');
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
     const nodeTypeSelect = screen.getByTestId('node-type-select');
-    expect(startDate).toBeInTheDocument();
+    expect(presetButton).toBeInTheDocument();
     expect(nodeTypeSelect).toBeInTheDocument();
   });
 
@@ -141,9 +142,9 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
     renderWithTheme(
       <CloudPulseDashboardWithFilters resource={1} serviceType="nodebalancer" />
     );
-    const startDate = screen.getByText('Start Date');
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
     const portsSelect = screen.getByPlaceholderText('e.g., 80,443,3000');
-    expect(startDate).toBeInTheDocument();
+    expect(presetButton).toBeInTheDocument();
     expect(portsSelect).toBeInTheDocument();
   });
 
@@ -159,8 +160,8 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
     renderWithTheme(
       <CloudPulseDashboardWithFilters resource={1} serviceType="firewall" />
     );
-    const startDate = screen.getByText('Start Date');
-    expect(startDate).toBeInTheDocument();
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
+    expect(presetButton).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Select a Linode Region')).toBeVisible();
     expect(screen.getByPlaceholderText('Select Interface Types')).toBeVisible();
     expect(screen.getByPlaceholderText('e.g., 1234,5678')).toBeVisible();
@@ -181,8 +182,8 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
       />
     );
 
-    const startDate = screen.getByText('Start Date');
-    expect(startDate).toBeInTheDocument();
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
+    expect(presetButton).toBeInTheDocument();
   });
 
   it('renders a CloudPulseDashboardWithFilters component with mandatory filter error for objectstorage if region is not provided', () => {
@@ -212,8 +213,8 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
       <CloudPulseDashboardWithFilters resource={1} serviceType="blockstorage" />
     );
 
-    const startDate = screen.getByText('Start Date');
-    expect(startDate).toBeInTheDocument();
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
+    expect(presetButton).toBeInTheDocument();
   });
 
   it('renders a CloudPulseDashboardWithFilters component successfully for firewall nodebalancer', async () => {
@@ -240,8 +241,8 @@ describe('CloudPulseDashboardWithFilters component tests', () => {
       <CloudPulseDashboardWithFilters resource={1} serviceType="firewall" />
     );
 
-    const startDate = screen.getByText('Start Date');
-    expect(startDate).toBeInTheDocument();
+    const presetButton = screen.getByTestId(PRESET_BUTTON_ID);
+    expect(presetButton).toBeInTheDocument();
     await userEvent.click(screen.getByPlaceholderText('Select a Dashboard'));
     await userEvent.click(screen.getByText('nodebalancer_firewall_dashbaord'));
     expect(

--- a/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.test.tsx
+++ b/packages/manager/src/features/CloudPulse/Overview/GlobalFilters.test.tsx
@@ -52,7 +52,7 @@ describe('Global filters component test', () => {
   it('Should have time range select with default value', () => {
     setup();
 
-    const timeRangeSelect = screen.getByText('Start Date');
+    const timeRangeSelect = screen.getByTestId('preset-button');
 
     expect(timeRangeSelect).toBeInTheDocument();
   });

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -33,6 +33,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
     const { defaultValue, handleStatsChange, savePreferences } = props;
     const { data: profile } = useProfile();
     let defaultSelected = defaultValue as DateTimeWithPreset;
+    const RESET = 'Reset';
     const theme = useTheme();
     const timezone =
       defaultSelected?.timeZone ??
@@ -94,7 +95,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
 
     return (
       <Box alignItems={'center'} display={'flex'}>
-        {showPreset !== 'Reset' && !openCalendar && (
+        {showPreset !== RESET && !openCalendar && (
           <Button
             buttonType="secondary"
             data-testid="preset-button"
@@ -121,7 +122,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             {defaultSelected.preset}
           </Button>
         )}
-        {(showPreset === 'Reset' || openCalendar) && (
+        {(showPreset === RESET || openCalendar) && (
           <DateTimeRangePicker
             endDateProps={{
               label: 'End Date',

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -68,13 +68,8 @@ export const CloudPulseDateTimeRangePicker = React.memo(
       if (!endDate || !startDate || !selectedPreset || !timeZone) {
         return;
       }
-      if (selectedPreset !== RESET) {
-        setOpenCalendar(false);
-        setSelectedPreset(selectedPreset);
-      } else {
-        setOpenCalendar(true);
-        setSelectedPreset(selectedPreset);
-      }
+      setOpenCalendar(selectedPreset !== RESET ? false : true);
+      setSelectedPreset(selectedPreset);
       handleStatsChange(
         {
           end: endDate,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -110,7 +110,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             }}
             sx={{
               marginTop: 3.5,
-              bottom: '2px',
+              bottom: (theme) => theme.spacingFunction(2),
               '&:hover': {
                 '& .MuiButton-endIcon svg': {
                   color: 'inherit',

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -50,7 +50,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
     );
 
     // Show calendar only if selected or default preset is 'reset' or button is clicked
-    const [openCalender, setOpenCalendar] = React.useState<boolean>(false);
+    const [openCalendar, setOpenCalendar] = React.useState<boolean>(false);
     React.useEffect(() => {
       if (defaultSelected) {
         handleStatsChange(defaultSelected);
@@ -94,7 +94,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
 
     return (
       <Box alignItems={'center'} display={'flex'}>
-        {showPreset !== 'Reset' && !openCalender && (
+        {showPreset !== 'Reset' && !openCalendar && (
           <Button
             buttonType="secondary"
             data-testid="preset-button"
@@ -111,7 +111,6 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             sx={{
               marginTop: 3.5,
               bottom: '2px',
-              display: showPreset ? 'flex' : 'none',
               '&:hover': {
                 '& .MuiButton-endIcon svg': {
                   color: 'inherit',
@@ -122,7 +121,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             {defaultSelected.preset}
           </Button>
         )}
-        {(showPreset === 'Reset' || openCalender) && (
+        {(showPreset === 'Reset' || openCalendar) && (
           <DateTimeRangePicker
             endDateProps={{
               label: 'End Date',
@@ -133,7 +132,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             format="yyyy-MM-dd hh:mm a"
             onApply={handleDateChange}
             onClose={handleClose}
-            openCalender={openCalender}
+            openCalendar={openCalendar}
             presetsProps={{
               defaultValue: defaultSelected?.preset,
               enablePresets: true,

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -1,5 +1,6 @@
 import { useProfile } from '@linode/queries';
-import { DateTimeRangePicker } from '@linode/ui';
+import { Box, Button, CalendarIcon, DateTimeRangePicker } from '@linode/ui';
+import { useTheme } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import React from 'react';
 
@@ -32,7 +33,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
     const { defaultValue, handleStatsChange, savePreferences } = props;
     const { data: profile } = useProfile();
     let defaultSelected = defaultValue as DateTimeWithPreset;
-
+    const theme = useTheme();
     const timezone =
       defaultSelected?.timeZone ??
       profile?.timezone ??
@@ -43,19 +44,36 @@ export const CloudPulseDateTimeRangePicker = React.memo(
     } else {
       defaultSelected = getTimeFromPreset(defaultSelected, timezone);
     }
+    // Show button with preset value only if selected or default preset is not 'reset'
+    const [showPreset, setPreset] = React.useState<string | undefined>(
+      defaultSelected.preset
+    );
 
+    // Show calendar only if selected or default preset is 'reset' or button is clicked
+    const [openCalender, setOpenCalendar] = React.useState<boolean>(false);
     React.useEffect(() => {
       if (defaultSelected) {
         handleStatsChange(defaultSelected);
       }
     }, []);
 
+    const handleClose = (selectedPreset: string) => {
+      setOpenCalendar(false);
+      setPreset(selectedPreset);
+    };
+
     const handleDateChange = (params: DateChangeProps) => {
       const { endDate, selectedPreset, startDate, timeZone } = params;
       if (!endDate || !startDate || !selectedPreset || !timeZone) {
         return;
       }
-
+      if (selectedPreset !== 'reset') {
+        setOpenCalendar(false);
+        setPreset(selectedPreset);
+      } else {
+        setOpenCalendar(true);
+        setPreset(selectedPreset);
+      }
       handleStatsChange(
         {
           end: endDate,
@@ -75,33 +93,67 @@ export const CloudPulseDateTimeRangePicker = React.memo(
       : end;
 
     return (
-      <DateTimeRangePicker
-        endDateProps={{
-          label: 'End Date',
-          placeholder: 'Select End Date',
-          showTimeZone: true,
-          value: end,
-        }}
-        format="yyyy-MM-dd hh:mm a"
-        onApply={handleDateChange}
-        presetsProps={{
-          defaultValue: defaultSelected?.preset,
-          enablePresets: true,
-        }}
-        startDateProps={{
-          label: 'Start Date',
-          placeholder: 'Select Start Date',
-          showTimeZone: true,
-          timeZoneValue: timezone,
-          value: start,
-        }}
-        sx={{
-          minWidth: '226px',
-        }}
-        timeZoneProps={{
-          defaultValue: timezone,
-        }}
-      />
+      <Box alignItems={'center'} display={'flex'}>
+        {showPreset !== 'Reset' && !openCalender && (
+          <Button
+            buttonType="secondary"
+            data-testid="preset-button"
+            endIcon={
+              <CalendarIcon
+                color={theme.tokens.alias.Background.Base}
+                height={24}
+                width={24}
+              />
+            }
+            onClick={() => {
+              setOpenCalendar(true);
+            }}
+            sx={{
+              marginTop: 3.5,
+              bottom: '2px',
+              display: showPreset ? 'flex' : 'none',
+              '&:hover': {
+                '& .MuiButton-endIcon svg': {
+                  color: 'inherit',
+                },
+              },
+            }}
+          >
+            {defaultSelected.preset}
+          </Button>
+        )}
+        {(showPreset === 'Reset' || openCalender) && (
+          <DateTimeRangePicker
+            endDateProps={{
+              label: 'End Date',
+              placeholder: 'Select End Date',
+              showTimeZone: true,
+              value: end,
+            }}
+            format="yyyy-MM-dd hh:mm a"
+            onApply={handleDateChange}
+            onClose={handleClose}
+            openCalender={openCalender}
+            presetsProps={{
+              defaultValue: defaultSelected?.preset,
+              enablePresets: true,
+            }}
+            startDateProps={{
+              label: 'Start Date',
+              placeholder: 'Select Start Date',
+              showTimeZone: true,
+              timeZoneValue: timezone,
+              value: start,
+            }}
+            sx={{
+              minWidth: '100px',
+            }}
+            timeZoneProps={{
+              defaultValue: timezone,
+            }}
+          />
+        )}
+      </Box>
     );
   }
 );

--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -46,9 +46,9 @@ export const CloudPulseDateTimeRangePicker = React.memo(
       defaultSelected = getTimeFromPreset(defaultSelected, timezone);
     }
     // Show button with preset value only if selected or default preset is not 'reset'
-    const [showPreset, setPreset] = React.useState<string | undefined>(
-      defaultSelected.preset
-    );
+    const [selectedPreset, setSelectedPreset] = React.useState<
+      string | undefined
+    >(defaultSelected.preset);
 
     // Show calendar only if selected or default preset is 'reset' or button is clicked
     const [openCalendar, setOpenCalendar] = React.useState<boolean>(false);
@@ -60,7 +60,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
 
     const handleClose = (selectedPreset: string) => {
       setOpenCalendar(false);
-      setPreset(selectedPreset);
+      setSelectedPreset(selectedPreset);
     };
 
     const handleDateChange = (params: DateChangeProps) => {
@@ -68,12 +68,12 @@ export const CloudPulseDateTimeRangePicker = React.memo(
       if (!endDate || !startDate || !selectedPreset || !timeZone) {
         return;
       }
-      if (selectedPreset !== 'reset') {
+      if (selectedPreset !== RESET) {
         setOpenCalendar(false);
-        setPreset(selectedPreset);
+        setSelectedPreset(selectedPreset);
       } else {
         setOpenCalendar(true);
-        setPreset(selectedPreset);
+        setSelectedPreset(selectedPreset);
       }
       handleStatsChange(
         {
@@ -95,7 +95,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
 
     return (
       <Box alignItems={'center'} display={'flex'}>
-        {showPreset !== RESET && !openCalendar && (
+        {selectedPreset !== RESET && !openCalendar && (
           <Button
             buttonType="secondary"
             data-testid="preset-button"
@@ -122,7 +122,7 @@ export const CloudPulseDateTimeRangePicker = React.memo(
             {defaultSelected.preset}
           </Button>
         )}
-        {(showPreset === RESET || openCalendar) && (
+        {(selectedPreset === RESET || openCalendar) && (
           <DateTimeRangePicker
             endDateProps={{
               label: 'End Date',

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseMonitor/DatabaseMonitor.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseMonitor/DatabaseMonitor.test.tsx
@@ -40,7 +40,7 @@ describe('database monitor', () => {
     expect(loadingElement).toBeInTheDocument();
     await waitForElementToBeRemoved(loadingElement);
 
-    const startDate = screen.getByText('Start Date');
-    expect(startDate).toBeInTheDocument();
+    const presetButton = screen.getByTestId('preset-button');
+    expect(presetButton).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -288,7 +288,7 @@ export const DateTimeRangePicker = ({
         startDateInputRef.current?.parentElement || startDateInputRef.current,
       );
     }
-  }, [anchorEl]);
+  }, []);
 
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -54,7 +54,7 @@ export interface DateTimeRangePickerProps {
 
   onClose?: (selectedPreset: string) => void;
 
-  openCalender?: boolean;
+  openCalendar?: boolean;
 
   /** Additional settings for the presets dropdown */
   presetsProps?: {
@@ -112,7 +112,7 @@ export const DateTimeRangePicker = ({
   startDateProps,
   sx,
   timeZoneProps,
-  openCalender,
+  openCalendar,
   onClose,
 }: DateTimeRangePickerProps) => {
   const [startDate, setStartDate] = useState<DateTime | null>(
@@ -128,7 +128,7 @@ export const DateTimeRangePicker = ({
     startDateProps?.errorMessage,
   );
   const [endDateError, setEndDateError] = useState(endDateProps?.errorMessage);
-  const [open, setOpen] = useState(openCalender ?? false);
+  const [open, setOpen] = useState(openCalendar ?? false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [currentMonth, setCurrentMonth] = useState(DateTime.now());
   const [focusedField, setFocusedField] = useState<'end' | 'start'>('start'); // Tracks focused input field

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -293,7 +293,16 @@ export const DateTimeRangePicker = ({
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Box>
-        <Stack direction="row" spacing={2} sx={sx}>
+        <Stack
+          sx={(theme) => ({
+            sx,
+            gap: theme.spacingFunction(16),
+            flexDirection: 'row',
+            [theme.breakpoints.down('md')]: {
+              flexDirection: 'column',
+            },
+          })}
+        >
           <DateTimeField
             errorText={startDateError}
             format={format}

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -52,8 +52,10 @@ export interface DateTimeRangePickerProps {
     timeZone: null | string;
   }) => void;
 
+  /** Callback when the popover is closed */
   onClose?: (selectedPreset: string) => void;
 
+  /** Property to control whether the calendar popover is open */
   openCalendar?: boolean;
 
   /** Additional settings for the presets dropdown */
@@ -337,7 +339,7 @@ export const DateTimeRangePicker = ({
           anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
           disableAutoFocus
           onClose={(event, reason) => {
-            // ✅ Block close only if clickaway
+            // Block close only if clickaway
             if (reason === 'backdropClick') return;
 
             handleClose();

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -52,6 +52,10 @@ export interface DateTimeRangePickerProps {
     timeZone: null | string;
   }) => void;
 
+  onClose?: (selectedPreset: string) => void;
+
+  openCalender?: boolean;
+
   /** Additional settings for the presets dropdown */
   presetsProps?: {
     /** Default value for the presets field */
@@ -106,8 +110,10 @@ export const DateTimeRangePicker = ({
   onApply,
   presetsProps,
   startDateProps,
-  timeZoneProps,
   sx,
+  timeZoneProps,
+  openCalender,
+  onClose,
 }: DateTimeRangePickerProps) => {
   const [startDate, setStartDate] = useState<DateTime | null>(
     startDateProps?.value ?? null,
@@ -122,7 +128,7 @@ export const DateTimeRangePicker = ({
     startDateProps?.errorMessage,
   );
   const [endDateError, setEndDateError] = useState(endDateProps?.errorMessage);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(openCalender ?? false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [currentMonth, setCurrentMonth] = useState(DateTime.now());
   const [focusedField, setFocusedField] = useState<'end' | 'start'>('start'); // Tracks focused input field
@@ -170,6 +176,7 @@ export const DateTimeRangePicker = ({
     setEndDateError('');
     setOpen(false);
     setAnchorEl(null);
+    onClose?.(previousValues.current.selectedPreset ?? '');
   };
 
   const handleApply = () => {
@@ -275,6 +282,14 @@ export const DateTimeRangePicker = ({
     setEndDateError('');
   };
 
+  React.useEffect(() => {
+    if (!anchorEl && startDateInputRef.current) {
+      setAnchorEl(
+        startDateInputRef.current?.parentElement || startDateInputRef.current,
+      );
+    }
+  }, [anchorEl]);
+
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Box>
@@ -312,7 +327,12 @@ export const DateTimeRangePicker = ({
           anchorEl={anchorEl}
           anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
           disableAutoFocus
-          onClose={handleClose}
+          onClose={(event, reason) => {
+            // ✅ Block close only if clickaway
+            if (reason === 'backdropClick') return;
+
+            handleClose();
+          }}
           open={open}
           role="dialog"
           slotProps={{
@@ -379,6 +399,7 @@ export const DateTimeRangePicker = ({
                   label="Start Time"
                   onChange={(newTime: DateTime | null) => {
                     if (newTime) {
+                      setSelectedPreset(PRESET_LABELS.RESET); // Reset preset on manual time change
                       setStartDate((prev) => {
                         const updatedValue =
                           prev?.set({
@@ -404,6 +425,7 @@ export const DateTimeRangePicker = ({
                   label="End Time"
                   onChange={(newTime: DateTime | null) => {
                     if (newTime) {
+                      setSelectedPreset(PRESET_LABELS.RESET); // Reset preset on manual time change
                       setEndDate((prev) => {
                         const updatedValue =
                           prev?.set({

--- a/packages/ui/src/components/DatePicker/TimeZoneSelect.tsx
+++ b/packages/ui/src/components/DatePicker/TimeZoneSelect.tsx
@@ -50,6 +50,7 @@ export const TimeZoneSelect = ({
     <Autocomplete
       autoHighlight
       data-qa-autocomplete="timezone-select"
+      disableClearable
       disabled={disabled}
       errorText={errorText}
       keepSearchEnabledOnMobile

--- a/packages/ui/src/utilities/timezones.ts
+++ b/packages/ui/src/utilities/timezones.ts
@@ -741,6 +741,11 @@ export const timezones = [
   },
   {
     label: 'Greenwich Mean Time',
+    name: 'GMT',
+    offset: 0,
+  },
+  {
+    label: 'Greenwich Mean Time',
     name: 'Etc/GMT',
     offset: 0,
   },


### PR DESCRIPTION
## Description 📝

Change the DateTimeRangePicker according to UX suggestions / improvements

## Changes  🔄

1. Show a preset button, if a pre-defined preset like, Last 1 hour, Last 30 minutes is selected.
2. Show start and end date if custom range selected
3. On click of a preset button, open the calendar popover, with updated time at the minute.


### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷
| Before  | After   |
| ------- | ------- |
|<video src="https://github.com/user-attachments/assets/d728cf09-446a-46ae-8e14-ede361992f16"/>|<video src="https://github.com/user-attachments/assets/6d46c5ad-973b-41ac-9490-ac333ad1a77a"/>|

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [x] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>
