### PR TITLE
upcoming: [DI-28563] - Time Range fix for backdrop close and contextual view retain selection

### DIFF
--- a/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
+++ b/packages/manager/src/features/CloudPulse/shared/CloudPulseDateTimeRangePicker.tsx
@@ -37,8 +37,9 @@ export const CloudPulseDateTimeRangePicker = React.memo(
     const theme = useTheme();
     const timezone =
       defaultSelected?.timeZone ??
-      profile?.timezone ??
-      DateTime.local().zoneName;
+      (profile?.timezone === 'GMT'
+        ? 'Etc/GMT' // this is present in timezone list for GMT
+        : (profile?.timezone ?? DateTime.local().zoneName));
 
     if (!defaultSelected) {
       defaultSelected = defaultTimeDuration(timezone);

--- a/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -293,16 +293,7 @@ export const DateTimeRangePicker = ({
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Box>
-        <Stack
-          sx={(theme) => ({
-            sx,
-            gap: theme.spacingFunction(16),
-            flexDirection: 'row',
-            [theme.breakpoints.down('md')]: {
-              flexDirection: 'column',
-            },
-          })}
-        >
+        <Stack direction={isSmallScreen ? 'column' : 'row'} spacing={2} sx={sx}>
           <DateTimeField
             errorText={startDateError}
             format={format}

--- a/packages/ui/src/utilities/timezones.ts
+++ b/packages/ui/src/utilities/timezones.ts
@@ -741,11 +741,6 @@ export const timezones = [
   },
   {
     label: 'Greenwich Mean Time',
-    name: 'GMT',
-    offset: 0,
-  },
-  {
-    label: 'Greenwich Mean Time',
     name: 'Etc/GMT',
     offset: 0,
   },


### PR DESCRIPTION
1. Allowed backdrop click close for time picker
2. The data retention issue in contextual view is also fixed