### PR TITLE
Minor bug fixes in TimeRangePicker and Humanize

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/volume-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/volume-widget-verification.spec.ts
@@ -240,7 +240,6 @@ describe('CloudPulse Blockstorage Dashboard – Refactored', () => {
       .invoke('attr', 'data-qa-selected')
       .should('eq', 'true');
 
-    cy.wait(['@getDashboard', '@getServiceType', '@getDatabase']);
     cy.wait(1000);
   });
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
@@ -183,7 +183,7 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
         }
         expect(metric[0].name).to.equal(metricData.name);
         expect(metric[0].aggregate_function).to.equal('min');
-        expect(timeRange).to.have.property('unit', 'days');
+        expect(timeRange).to.have.property('unit', 'hr');
         expect(timeRange).to.have.property('value', 1);
         expect(entity_ids).to.deep.equal([1]);
         const filtersStr = JSON.stringify(filters);
@@ -208,7 +208,7 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
       .should('be.visible')
       .should('be.enabled')
       .click();
-    // Select a Database Engine from the autocomplete input.
+    // Select a Database Engine from the autocomplete input.days
     ui.autocomplete
       .findByLabel('Database Engine')
       .should('be.visible')

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -1,5 +1,7 @@
+import { useProfile } from '@linode/queries';
 import { Box, Paper } from '@linode/ui';
 import { GridLegacy } from '@mui/material';
+import { DateTime } from 'luxon';
 import * as React from 'react';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -8,6 +10,7 @@ import { SuspenseLoader } from 'src/components/SuspenseLoader';
 
 import { GlobalFilters } from '../Overview/GlobalFilters';
 import { CloudPulseAppliedFilterRenderer } from '../shared/CloudPulseAppliedFilterRenderer';
+import { defaultTimeDuration } from '../Utils/CloudPulseDateTimePickerUtils';
 import { CloudPulseDashboardRenderer } from './CloudPulseDashboardRenderer';
 
 import type { Dashboard, DateTimeWithPreset } from '@linode/api-v4';
@@ -29,6 +32,7 @@ export interface DashboardProp {
 }
 
 export const CloudPulseDashboardLanding = () => {
+  const { data: profile } = useProfile();
   const [filterData, setFilterData] = React.useState<FilterData>({
     id: {},
     label: {},
@@ -44,6 +48,11 @@ export const CloudPulseDashboardLanding = () => {
 
   const [showAppliedFilters, setShowAppliedFilters] =
     React.useState<boolean>(false);
+
+  const timezone =
+    profile?.timezone === 'GMT'
+      ? 'Etc/GMT' // this is present in timezone list for GMT
+      : (profile?.timezone ?? DateTime.local().zoneName);
 
   const toggleAppliedFilter = (isVisible: boolean) => {
     setShowAppliedFilters(isVisible);
@@ -77,6 +86,7 @@ export const CloudPulseDashboardLanding = () => {
       id: {},
       label: {},
     }); // clear the filter values on dashboard change
+    setTimeDuration(defaultTimeDuration(timezone)); // clear time duration on dashboard change
   }, []);
   const onTimeDurationChange = React.useCallback(
     (timeDurationObj: DateTimeWithPreset) => {

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardLanding.tsx
@@ -80,14 +80,17 @@ export const CloudPulseDashboardLanding = () => {
     []
   );
 
-  const onDashboardChange = React.useCallback((dashboardObj: Dashboard) => {
-    setDashboard(dashboardObj);
-    setFilterData({
-      id: {},
-      label: {},
-    }); // clear the filter values on dashboard change
-    setTimeDuration(defaultTimeDuration(timezone)); // clear time duration on dashboard change
-  }, []);
+  const onDashboardChange = React.useCallback(
+    (dashboardObj: Dashboard) => {
+      setDashboard(dashboardObj);
+      setFilterData({
+        id: {},
+        label: {},
+      }); // clear the filter values on dashboard change
+      setTimeDuration(defaultTimeDuration(timezone)); // clear time duration on dashboard change
+    },
+    [timezone]
+  );
   const onTimeDurationChange = React.useCallback(
     (timeDurationObj: DateTimeWithPreset) => {
       setTimeDuration(timeDurationObj);

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -127,7 +127,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
         setDashboard(dashboard);
         setTimeDuration(defaultTimeDuration(timezone)); // clear time duration on dashboard change
       },
-      []
+      [timezone]
     );
 
     const handleTimeRangeChange = React.useCallback(

--- a/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
+++ b/packages/manager/src/features/CloudPulse/Dashboard/CloudPulseDashboardWithFilters.tsx
@@ -1,5 +1,7 @@
+import { useProfile } from '@linode/queries';
 import { Box, CircleProgress, Divider, ErrorState, Paper } from '@linode/ui';
 import { GridLegacy } from '@mui/material';
+import { DateTime } from 'luxon';
 import React from 'react';
 
 import {
@@ -13,7 +15,7 @@ import { CloudPulseDashboardFilterBuilder } from '../shared/CloudPulseDashboardF
 import { CloudPulseDashboardSelect } from '../shared/CloudPulseDashboardSelect';
 import { CloudPulseDateTimeRangePicker } from '../shared/CloudPulseDateTimeRangePicker';
 import { CloudPulseErrorPlaceholder } from '../shared/CloudPulseErrorPlaceholder';
-import { convertToGmt } from '../Utils/CloudPulseDateTimePickerUtils';
+import { convertToGmt, defaultTimeDuration } from '../Utils/CloudPulseDateTimePickerUtils';
 import { PARENT_ENTITY_REGION } from '../Utils/constants';
 import { FILTER_CONFIG } from '../Utils/FilterConfig';
 import {
@@ -62,6 +64,8 @@ export const CloudPulseDashboardWithFilters = React.memo(
       serviceType ? [serviceType] : []
     );
 
+    const { data: profile } = useProfile();
+
     const [filterData, setFilterData] = React.useState<FilterData>({
       id: {},
       label: {},
@@ -85,6 +89,11 @@ export const CloudPulseDashboardWithFilters = React.memo(
 
     const [showAppliedFilters, setShowAppliedFilters] =
       React.useState<boolean>(false);
+
+    const timezone =
+      profile?.timezone === 'GMT'
+        ? 'Etc/GMT' // this is present in timezone list for GMT
+        : (profile?.timezone ?? DateTime.local().zoneName);
 
     const toggleAppliedFilter = (isVisible: boolean) => {
       setShowAppliedFilters(isVisible);
@@ -116,6 +125,7 @@ export const CloudPulseDashboardWithFilters = React.memo(
       (dashboard: Dashboard | undefined) => {
         setFilterData({ id: {}, label: {} });
         setDashboard(dashboard);
+        setTimeDuration(defaultTimeDuration(timezone)); // clear time duration on dashboard change
       },
       []
     );

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -1,6 +1,5 @@
 import { formatPercentage } from '@linode/utilities';
 
-import * as utilities from 'src/components/AreaChart/utils';
 import { widgetFactory } from 'src/factories';
 
 import {
@@ -12,6 +11,7 @@ import {
   getTimeDurationFromPreset,
   mapResourceIdToName,
 } from './CloudPulseWidgetUtils';
+import * as utilities from './CloudPulseWidgetUtils';
 
 import type {
   DimensionNameProperties,

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.test.ts
@@ -11,7 +11,7 @@ import {
   getTimeDurationFromPreset,
   mapResourceIdToName,
 } from './CloudPulseWidgetUtils';
-import * as utilities from './CloudPulseWidgetUtils';
+import * as utilities from './utils';
 
 import type {
   DimensionNameProperties,

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -289,7 +289,8 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
         const legendRow: MetricsDisplayRow = {
           data: getMetrics(data as number[][]),
           format: isUnitPresent
-            ? (value: number) => `${humanizeLargeData(value)} ${unit}` // we need to humanize count values in legend
+            ? (value: number) =>
+                `${value < 1000 ? formatToolTip(value, unit) : `${humanizeLargeData(value)} ${unit}`}` // we need to humanize count values in legend
             : (value: number) => formatToolTip(value, unit),
           legendColor: color,
           legendTitle: labelName,

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -2,8 +2,6 @@ import { Alias } from '@linode/design-language-system';
 import { DateTimeRangePicker } from '@linode/ui';
 import { getMetrics } from '@linode/utilities';
 
-import { humanizeLargeData } from 'src/components/AreaChart/utils';
-
 import { DIMENSION_TRANSFORM_CONFIG } from '../shared/DimensionTransform';
 import {
   convertValueToUnit,
@@ -582,4 +580,27 @@ export const getTimeDurationFromPreset = (
     default:
       return undefined;
   }
+};
+
+/**
+ * @param value The numeric value to humanize
+ * @returns The humanized string representation of the value
+ */
+export const humanizeLargeData = (value: number) => {
+  if (value >= 1000000000000) {
+    return +(value / 1000000000000).toFixed(1) + 'T';
+  }
+  if (value >= 1000000000) {
+    return +(value / 1000000000).toFixed(1) + 'B';
+  }
+  if (value >= 1000000) {
+    return +(value / 1000000).toFixed(1) + 'M';
+  }
+  if (value >= 100000) {
+    return +(value / 1000).toFixed(0) + 'K';
+  }
+  if (value >= 1000) {
+    return +(value / 1000).toFixed(1) + 'K';
+  }
+  return `${value.toFixed(3)}`;
 };

--- a/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/CloudPulseWidgetUtils.ts
@@ -11,6 +11,7 @@ import {
 } from './unitConversion';
 import {
   convertTimeDurationToStartAndEndTimeRange,
+  humanizeLargeData,
   seriesDataFormatter,
 } from './utils';
 
@@ -287,8 +288,7 @@ export const generateGraphData = (props: GraphDataOptionsProps): GraphData => {
         const legendRow: MetricsDisplayRow = {
           data: getMetrics(data as number[][]),
           format: isUnitPresent
-            ? (value: number) =>
-                `${value < 1000 ? formatToolTip(value, unit) : `${humanizeLargeData(value)} ${unit}`}` // we need to humanize count values in legend
+            ? (value: number) => `${humanizeLargeData(value)} ${unit}` // we need to humanize count values in legend
             : (value: number) => formatToolTip(value, unit),
           legendColor: color,
           legendTitle: labelName,
@@ -580,27 +580,4 @@ export const getTimeDurationFromPreset = (
     default:
       return undefined;
   }
-};
-
-/**
- * @param value The numeric value to humanize
- * @returns The humanized string representation of the value
- */
-export const humanizeLargeData = (value: number) => {
-  if (value >= 1000000000000) {
-    return +(value / 1000000000000).toFixed(1) + 'T';
-  }
-  if (value >= 1000000000) {
-    return +(value / 1000000000).toFixed(1) + 'B';
-  }
-  if (value >= 1000000) {
-    return +(value / 1000000).toFixed(1) + 'M';
-  }
-  if (value >= 100000) {
-    return +(value / 1000).toFixed(0) + 'K';
-  }
-  if (value >= 1000) {
-    return +(value / 1000).toFixed(1) + 'K';
-  }
-  return `${value.toFixed(3)}`;
 };

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -711,3 +711,26 @@ export const arraysEqual = (
     [...b].sort((x, y) => x - y)
   );
 };
+
+/**
+ * @param value The numeric value to humanize
+ * @returns The humanized string representation of the value
+ */
+export const humanizeLargeData = (value: number) => {
+  if (value >= 1000000000000) {
+    return +(value / 1000000000000).toFixed(1) + 'T';
+  }
+  if (value >= 1000000000) {
+    return +(value / 1000000000).toFixed(1) + 'B';
+  }
+  if (value >= 1000000) {
+    return +(value / 1000000).toFixed(1) + 'M';
+  }
+  if (value >= 100000) {
+    return +(value / 1000).toFixed(0) + 'K';
+  }
+  if (value >= 1000) {
+    return +(value / 1000).toFixed(1) + 'K';
+  }
+  return `${value.toFixed(2)}`;
+};

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -732,5 +732,5 @@ export const humanizeLargeData = (value: number) => {
   if (value >= 1000) {
     return +(value / 1000).toFixed(1) + 'K';
   }
-  return `${value.toFixed(2)}`;
+  return value === 0 ? `${value}` : `${value.toFixed(1)}`;
 };

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -732,5 +732,5 @@ export const humanizeLargeData = (value: number) => {
   if (value >= 1000) {
     return +(value / 1000).toFixed(1) + 'K';
   }
-  return `${roundTo(value)}`;
+  return `${roundTo(value, 1)}`;
 };

--- a/packages/manager/src/features/CloudPulse/Utils/utils.ts
+++ b/packages/manager/src/features/CloudPulse/Utils/utils.ts
@@ -1,5 +1,5 @@
 import { useAccount, useRegionsQuery } from '@linode/queries';
-import { isFeatureEnabledV2 } from '@linode/utilities';
+import { isFeatureEnabledV2, roundTo } from '@linode/utilities';
 import React from 'react';
 
 import { convertData } from 'src/features/Longview/shared/formatters';
@@ -732,5 +732,5 @@ export const humanizeLargeData = (value: number) => {
   if (value >= 1000) {
     return +(value / 1000).toFixed(1) + 'K';
   }
-  return value === 0 ? `${value}` : `${value.toFixed(1)}`;
+  return `${roundTo(value)}`;
 };

--- a/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/CloudPulseWidget.tsx
@@ -446,7 +446,7 @@ export const CloudPulseWidget = (props: CloudPulseWidgetProperties) => {
       serviceType,
       groupBy: [...globalFilterGroupBy, ...(groupBy ?? [])],
       metricLabel: availableMetrics?.label,
-      humanizableUnits: flags.aclp?.humanizableUnits ?? [],
+      humanizableUnits: flags.aclp?.humanizableUnits ?? ['Count'],
     });
 
     data = generatedData.dimensions;

--- a/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
@@ -4,8 +4,9 @@ import { Box, useMediaQuery, useTheme } from '@mui/material';
 import * as React from 'react';
 
 import { AreaChart } from 'src/components/AreaChart/AreaChart';
-import { humanizeLargeData } from 'src/components/AreaChart/utils';
 import { useFlags } from 'src/hooks/useFlags';
+
+import { humanizeLargeData } from '../../Utils/CloudPulseWidgetUtils';
 
 import type { AreaChartProps } from 'src/components/AreaChart/AreaChart';
 
@@ -69,10 +70,7 @@ export const CloudPulseLineGraph = React.memo((props: CloudPulseLineGraph) => {
           yAxisProps={
             isHumanizableUnit
               ? {
-                  tickFormat: (value: number) =>
-                    value < 1000
-                      ? `${roundTo(value, 3)}`
-                      : `${humanizeLargeData(value)}`,
+                  tickFormat: (value: number) => `${humanizeLargeData(value)}`,
                 }
               : {
                   tickFormat: (value: number) => `${roundTo(value, 3)}`,

--- a/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
@@ -68,7 +68,12 @@ export const CloudPulseLineGraph = React.memo((props: CloudPulseLineGraph) => {
           }
           yAxisProps={
             isHumanizableUnit
-              ? undefined
+              ? {
+                  tickFormat: (value: number) =>
+                    value < 1000
+                      ? `${roundTo(value, 3)}`
+                      : `${humanizeLargeData(value)}`,
+                }
               : {
                   tickFormat: (value: number) => `${roundTo(value, 3)}`,
                 }

--- a/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
+++ b/packages/manager/src/features/CloudPulse/Widget/components/CloudPulseLineGraph.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { AreaChart } from 'src/components/AreaChart/AreaChart';
 import { useFlags } from 'src/hooks/useFlags';
 
-import { humanizeLargeData } from '../../Utils/CloudPulseWidgetUtils';
+import { humanizeLargeData } from '../../Utils/utils';
 
 import type { AreaChartProps } from 'src/components/AreaChart/AreaChart';
 
@@ -33,9 +33,11 @@ export const CloudPulseLineGraph = React.memo((props: CloudPulseLineGraph) => {
 
   const noDataMessage = 'No data to display';
   const isHumanizableUnit =
-    flags.aclp?.humanizableUnits?.some(
+    flags.aclp?.humanizableUnits ??
+    ['Count']?.some(
       (unitElement) => unitElement.toLowerCase() === unit.toLowerCase()
-    ) ?? false;
+    ) ??
+    false;
   return (
     <Box
       sx={{


### PR DESCRIPTION
1. For the time range picker, on clear of dashboard or change of dashboard, reset the time to last one hour
2. For the humanize, for values less than 1000, round of 1 decimal place