### PR TITLE
23rddec issue venky december 23

### DIFF
--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/alert-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/alert-verification.spec.ts
@@ -11,7 +11,7 @@ import {
   mockGetAllAlertDefinitions,
 } from 'support/intercepts/cloudpulse';
 import { mockAppendFeatureFlags } from 'support/intercepts/feature-flags';
-import { mockGetLinodes } from 'support/intercepts/linodes';
+import { mockGetLinodes, mockUpdateLinode } from 'support/intercepts/linodes';
 import { mockGetRegions } from 'support/intercepts/regions';
 import { ui } from 'support/ui';
 import { cleanUp } from 'support/util/cleanup';
@@ -204,6 +204,7 @@ describe('update linode label', () => {
         'getDBaaSAlertDefinitions'
       );
       mockGetAllAlertDefinitions(alerts).as('getAlertDefinitionsList');
+      mockUpdateLinode(linode.id, mockLinodes[0]).as('updateLinode');
 
       mockAddEntityToAlert(serviceType, '100', { [ALERT_TYPE]: 100 }).as(
         'addEntityToAlert'

--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/alert-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/alert-verification.spec.ts
@@ -1,8 +1,8 @@
-import { linodeFactory, regionFactory } from '@linode/utilities';
-import { authenticate } from 'support/api/authentication';
 /**
  * @file Integration Tests for contextual view of Entity Listing.
  */
+import { linodeFactory, regionFactory } from '@linode/utilities';
+import { authenticate } from 'support/api/authentication';
 import { mockGetAccount } from 'support/intercepts/account';
 import {
   mockAddEntityToAlert,

--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/linode-firewall-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/linode-firewall-widget-verification.spec.ts
@@ -31,6 +31,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse, Filters } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -125,12 +126,17 @@ const getWidgetLegendRowValuesFromResponse = (
   // Destructure metrics data from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 const mockRegion = regionFactory.build({
   capabilities: ['Linodes', 'Cloud Firewall'],

--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/nodebalancer-firewall-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/nodebalancer-firewall-widget-verification.spec.ts
@@ -31,6 +31,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -106,12 +107,17 @@ const getWidgetLegendRowValuesFromResponse = (
   // Destructure metrics data from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 const mockRegion = regionFactory.build({
   capabilities: ['Linodes', 'Cloud Firewall'],

--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/object-storage-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/object-storage-widget-verification.spec.ts
@@ -41,6 +41,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type {
   CloudPulseMetricsResponse,
@@ -139,15 +140,21 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['entity_id'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 
 describe('Integration Tests for Object Storage Dashboard - Group By and Widget Verification', () => {

--- a/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/volume-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/contextual-view/volume-widget-verification.spec.ts
@@ -31,6 +31,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -127,12 +128,20 @@ const getExpectedLegendValues = (
     groupBy: ['entity_id'],
   });
 
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
   return {
-    average: formatToolTip(average, unit),
-    last: formatToolTip(last, unit),
-    max: formatToolTip(max, unit),
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
   };
 };
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/dbaas-updatewidgets-verification.spec.ts
@@ -208,7 +208,7 @@ describe('Integration tests for verifying Cloudpulse custom and preset configura
       .should('be.visible')
       .should('be.enabled')
       .click();
-    // Select a Database Engine from the autocomplete input.days
+    // Select a Database Engine from the autocomplete input.
     ui.autocomplete
       .findByLabel('Database Engine')
       .should('be.visible')

--- a/packages/manager/cypress/e2e/core/cloudpulse/firewall-nodebalancer-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/firewall-nodebalancer-widget-verification.spec.ts
@@ -31,6 +31,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -101,17 +102,16 @@ const metricDefinitions = metrics.map(({ name, title, unit }) =>
 /**
  * Generates graph data from a given CloudPulse metrics response and
  * extracts average, last, and maximum metric values from the first
- * legend row. The values are rounded to two decimal places for
- * better readability.
+ * legend row. Values are formatted for readability:
+ * - If the unit is "count", values are humanized (e.g., 1000000 → 1M).
+ * - Otherwise, values are formatted using `formatToolTip`.
  *
- * @param responsePayload - The metrics response object containing
- *                          the necessary data for graph generation.
+ * @param responsePayload - The metrics response object containing the necessary data.
  * @param label - The label for the graph, used for display purposes.
+ * @param unit - The unit of the metric (e.g., 'count', 'B', 'ms').
  *
- * @returns An object containing rounded values for average, last,
- *
+ * @returns An object containing formatted values for average, last, and maximum metrics.
  */
-
 const getWidgetLegendRowValuesFromResponse = (
   responsePayload: CloudPulseMetricsResponse,
   label: string,
@@ -134,15 +134,21 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['entity_id'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 
 const mockRegions = [

--- a/packages/manager/cypress/e2e/core/cloudpulse/firewall-nodebalancer-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/firewall-nodebalancer-widget-verification.spec.ts
@@ -139,7 +139,7 @@ const getWidgetLegendRowValuesFromResponse = (
 
   // Helper function to format value based on unit
   const formatValue = (value: number) =>
-    unit === 'count'
+    unit.toLowerCase() === 'count'
       ? `${humanizeLargeData(value)} ${unit}`
       : formatToolTip(value, unit);
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/firewall-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/firewall-widget-verification.spec.ts
@@ -29,6 +29,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse, Filters } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -117,12 +118,17 @@ const getWidgetLegendRowValuesFromResponse = (
   // Destructure metrics data from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 const mockLinode = linodeFactory.build({
   id: 1,

--- a/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
@@ -195,7 +195,7 @@ const getWidgetLegendRowValuesFromResponse = (
   const { average, last, max } = graphData.legendRowsData[0].data;
 
   const formatValue = (value: number) =>
-    unit.toLowerCase() === 'Count'
+    unit.toLowerCase() === 'count'
       ? `${humanizeLargeData(value)} ${unit}`
       : formatToolTip(value, unit);
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
@@ -195,7 +195,7 @@ const getWidgetLegendRowValuesFromResponse = (
   const { average, last, max } = graphData.legendRowsData[0].data;
 
   const formatValue = (value: number) =>
-    unit === 'Cpruount'
+    unit === 'Count'
       ? `${humanizeLargeData(value)} ${unit}`
       : formatToolTip(value, unit);
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
@@ -155,20 +155,20 @@ const metricsAPIResponsePayload = cloudPulseMetricsResponseFactory.build({
     ),
   },
 });
+
 /**
  * Generates graph data from a given CloudPulse metrics response and
  * extracts average, last, and maximum metric values from the first
- * legend row. The values are rounded to two decimal places for
- * better readability.
+ * legend row. Values are formatted for readability:
+ * - If the unit is "count", values are humanized (e.g., 1000000 → 1M).
+ * - Otherwise, values are formatted using `formatToolTip`.
  *
- * @param responsePayload - The metrics response object containing
- *                          the necessary data for graph generation.
+ * @param responsePayload - The metrics response object containing the necessary data.
  * @param label - The label for the graph, used for display purposes.
+ * @param unit - The unit of the metric (e.g., 'count', 'B', 'ms').
  *
- * @returns An object containing rounded values for average, last,
- *
+ * @returns An object containing formatted values for average, last, and maximum metrics.
  */
-
 const getWidgetLegendRowValuesFromResponse = (
   responsePayload: CloudPulseMetricsResponse,
   label: string,
@@ -182,7 +182,7 @@ const getWidgetLegendRowValuesFromResponse = (
       {
         id: '1',
         label: resource,
-        region: 'us-ord',
+        region: 'us-east',
       },
     ],
     status: 'success',
@@ -191,16 +191,22 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['entity_id'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  const formatValue = (value: number) =>
+    unit.toLowerCase() === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
+
 const mockedEnterpriseClusters = [
   kubernetesClusterFactory.build({
     label: resource,

--- a/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
@@ -195,7 +195,7 @@ const getWidgetLegendRowValuesFromResponse = (
   const { average, last, max } = graphData.legendRowsData[0].data;
 
   const formatValue = (value: number) =>
-    unit.toLowerCase() === 'count'
+    unit === 'Cpruount'
       ? `${humanizeLargeData(value)} ${unit}`
       : formatToolTip(value, unit);
 

--- a/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/lke-widgets-verification.spec.ts
@@ -195,7 +195,7 @@ const getWidgetLegendRowValuesFromResponse = (
   const { average, last, max } = graphData.legendRowsData[0].data;
 
   const formatValue = (value: number) =>
-    unit === 'Count'
+    unit === 'count'
       ? `${humanizeLargeData(value)} ${unit}`
       : formatToolTip(value, unit);
 
@@ -700,8 +700,6 @@ describe('Integration Tests for LKE Enterprise Dashboard ', () => {
             cy.get(graphRowTitle)
               .should('be.visible')
               .should('have.text', `${testData.title}`);
-
-            cy.log('expectedWidgetValues ', expectedWidgetValues.max);
 
             cy.get('[data-qa-graph-column-title="Max"]')
               .should('be.visible')

--- a/packages/manager/cypress/e2e/core/cloudpulse/object-strorage-endpoint-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/object-strorage-endpoint-widget-verification.spec.ts
@@ -34,6 +34,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type {
   CloudPulseMetricsResponse,
@@ -158,15 +159,21 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['endpoint'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 
 describe('Integration Tests for Object Storage Dashboard ', () => {

--- a/packages/manager/cypress/e2e/core/cloudpulse/object-strorage-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/object-strorage-widget-verification.spec.ts
@@ -34,6 +34,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type {
   CloudPulseMetricsResponse,
@@ -156,15 +157,21 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['entity_id'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 
 describe('Integration Tests for Object Storage Dashboard ', () => {

--- a/packages/manager/cypress/e2e/core/cloudpulse/volume-widget-verification.spec.ts
+++ b/packages/manager/cypress/e2e/core/cloudpulse/volume-widget-verification.spec.ts
@@ -30,6 +30,7 @@ import {
 } from 'src/factories';
 import { generateGraphData } from 'src/features/CloudPulse/Utils/CloudPulseWidgetUtils';
 import { formatToolTip } from 'src/features/CloudPulse/Utils/unitConversion';
+import { humanizeLargeData } from 'src/features/CloudPulse/Utils/utils';
 
 import type { CloudPulseMetricsResponse, Dashboard } from '@linode/api-v4';
 import type { Interception } from 'support/cypress-exports';
@@ -182,15 +183,21 @@ const getWidgetLegendRowValuesFromResponse = (
     groupBy: ['entity_id'],
   });
 
-  // Destructure metrics data from the first legend row
+  // Extract metrics from the first legend row
   const { average, last, max } = graphData.legendRowsData[0].data;
 
-  // Round the metrics values to two decimal places
-  const roundedAverage = formatToolTip(average, unit);
-  const roundedLast = formatToolTip(last, unit);
-  const roundedMax = formatToolTip(max, unit);
-  // Return the rounded values in an object
-  return { average: roundedAverage, last: roundedLast, max: roundedMax };
+  // Helper function to format value based on unit
+  const formatValue = (value: number) =>
+    unit === 'Count'
+      ? `${humanizeLargeData(value)} ${unit}`
+      : formatToolTip(value, unit);
+
+  // Return formatted metrics
+  return {
+    average: formatValue(average),
+    last: formatValue(last),
+    max: formatValue(max),
+  };
 };
 const mockVolumesEncrypted = [
   volumeFactory.build({


### PR DESCRIPTION
## Description 📝

Pull request overview
This PR implements humanized formatting for large numeric values in CloudPulse widgets and adds timezone support for dashboard filtering. The changes include moving the humanizeLargeData utility to a shared location, applying it to "Count" unit metrics, and ensuring time duration resets to user timezone defaults when switching dashboards.

Key Changes
Moved humanizeLargeData function from AreaChart utils to CloudPulse utils and applied it to format large numbers in "Count" metrics
Added timezone-based time duration reset when switching dashboards in CloudPulse
Updated test files to use the relocated humanizeLargeData function and apply proper formatting for "Count" units
- ...
- ...

### Scope 🚢

 Upon production release, changes in this PR will be visible to:

- [ ] All customers
- [ ] Some customers (e.g. in Beta or Limited Availability)
- [ ] No customers / Not applicable

## Target release date 🗓️

Please specify a release date (and environment, if applicable) to guarantee timely review of this PR. If exact date is not known, please approximate and update it as needed.

## Preview 📷

**Include a screenshot `<img src="" />` or video `<video src="" />` of the change.**

:lock: Use the [Mask Sensitive Data](https://cloud.linode.com/profile/settings) setting for security.

:bulb: For changes requiring multiple steps to validate, prefer a video for clarity.

| Before  | After   |
| ------- | ------- |
| 📷 | 📷 |

## How to test 🧪

### Prerequisites

(How to setup test environment)

- ...
- ...

### Reproduction steps

(How to reproduce the issue, if applicable)

- [ ] ...
- [ ] ...

### Verification steps

(How to verify changes)

- [ ] ...
- [ ] ...

<details>
<summary> Author Checklists </summary>

## As an Author, to speed up the review process, I considered 🤔

*Check all that apply*

- [ ] Use React components instead of HTML Tags
- [ ] Proper naming conventions like cameCase for variables & Function & snake_case for constants
- [ ] Use appropriate types & avoid using "any"
- [ ] No type casting & non-null assertions
- [ ] Adding a [changeset](https://github.com/linode/manager/blob/develop/docs/CONTRIBUTING.md#writing-a-changeset)
- [ ] Providing/Improving test coverage
- [ ] Use sx props to pass styles instead of style prop
- [ ] Add JSDoc comments for interface properties & functions
- [ ] Use strict equality (===) instead of double equal (==)
- [ ] Use of named arguments (interfaces) if function argument list exceeds size 2
- [ ] Destructure the props
- [ ] Keep component size small & move big computing functions to separate utility
- [ ] 📱 Providing mobile support

<br/>

- [ ] I have read and considered all applicable items listed above.

## As an Author, before moving this PR from Draft to Open, I confirmed ✅

- [ ] All tests and CI checks are passing
- [ ] TypeScript compilation succeeded without errors
- [ ] Code passes all linting rules

</details>

<!-- This content will not appear in the rendered Markdown 

## Commit message and pull request title format standards

> **Note**: Remove this section before opening the pull request
**Make sure your PR title and commit message on squash and merge are as shown below**

`<commit type>: [JIRA-ticket-number] - <description>`

**Commit Types:**

- `feat`: New feature for the user (not a part of the code, or ci, ...).
- `fix`: Bugfix for the user (not a fix to build something, ...).
- `change`: Modifying an existing visual UI instance. Such as a component or a feature.
- `refactor`: Restructuring existing code without changing its external behavior or visual UI. Typically to improve readability, maintainability, and performance.
- `test`: New tests or changes to existing tests. Does not change the production code.
- `upcoming`: A new feature that is in progress, not visible to users yet, and usually behind a feature flag.

**Example:** `feat: [M3-1234] - Allow user to view their login history`

-->